### PR TITLE
Return an error when an unexpected state is provided

### DIFF
--- a/driver/sql/postgres/projector.go
+++ b/driver/sql/postgres/projector.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql/driver"
+	"errors"
 
 	"github.com/hellofresh/goengine/driver/sql"
 )
@@ -44,4 +45,13 @@ func resolveErrorAction(
 	}
 
 	return errorFallthrough
+}
+
+// defaultProjectionStateEncoder this `ProjectionStateEncoder` is used for a goeninge.Projection
+func defaultProjectionStateEncoder(state interface{}) ([]byte, error) {
+	if state == nil {
+		return []byte{'{', '}'}, nil
+	}
+
+	return nil, errors.New("unexpected state provided (Did you forget to implement goengine.ProjectionSaga?)")
 }

--- a/driver/sql/postgres/projector_aggregate_storage.go
+++ b/driver/sql/postgres/projector_aggregate_storage.go
@@ -61,6 +61,7 @@ func newAggregateProjectionStorage(
 	projectionTableStr := QuoteString(projectionTable)
 	eventStoreTableQuoted := QuoteIdentifier(eventStoreTable)
 
+	/* #nosec */
 	return &aggregateProjectionStorage{
 		projectionStateEncoder: projectionStateEncoder,
 		logger:                 logger,
@@ -188,8 +189,8 @@ func (a *aggregateProjectionStorage) Acquire(
 	// Set the projection as row locked
 	_, err := conn.ExecContext(ctx, a.querySetRowLocked, aggregateID, true)
 	if err != nil {
-		if err := a.releaseProjection(conn, aggregateID); err != nil {
-			logger.WithError(err).Error("failed to release lock while setting projection rows as locked")
+		if releaseErr := a.releaseProjection(conn, aggregateID); releaseErr != nil {
+			logger.WithError(releaseErr).Error("failed to release lock while setting projection rows as locked")
 		} else {
 			logger.Debug("failed to set projection as locked")
 		}

--- a/driver/sql/postgres/projector_aggregate_storage_test.go
+++ b/driver/sql/postgres/projector_aggregate_storage_test.go
@@ -1,0 +1,89 @@
+// +build unit
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/hellofresh/goengine"
+	driverSQL "github.com/hellofresh/goengine/driver/sql"
+	"github.com/hellofresh/goengine/driver/sql/internal/test"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateProjectionStorage_PersistState(t *testing.T) {
+	mockedProjectionState := "I'm a projection state"
+	notification := &driverSQL.ProjectionNotification{
+		No:          1,
+		AggregateID: "d8490e85-dd22-4c32-9cb0-a29e57949951",
+	}
+	projectionState := driverSQL.ProjectionState{
+		Position:        5,
+		ProjectionState: mockedProjectionState,
+	}
+
+	test.RunWithMockDB(t, "Persist projection state", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		stateEncoderCalls := 0
+		stateEncoder := func(i interface{}) (bytes []byte, e error) {
+			assert.Equal(t, mockedProjectionState, i)
+
+			stateEncoderCalls++
+			return []byte(mockedProjectionState), nil
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newAggregateProjectionStorage("store_table", "projection_table", stateEncoder, goengine.NopLogger)
+		require.NoError(t, err)
+
+		dbMock.ExpectExec("^UPDATE \"projection_table\" SET").
+			WithArgs(notification.AggregateID, 5, []byte(mockedProjectionState)).
+			WillReturnResult(sqlmock.NewResult(18, 1))
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, stateEncoderCalls)
+	})
+
+	test.RunWithMockDB(t, "Persist projection state (using default encoder)", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		projectionState := driverSQL.ProjectionState{
+			Position:        6,
+			ProjectionState: nil,
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newAggregateProjectionStorage("store_table", "projection_table", nil, goengine.NopLogger)
+		require.NoError(t, err)
+
+		dbMock.ExpectExec("^UPDATE \"projection_table\" SET").
+			WithArgs(notification.AggregateID, 6, []byte("{}")).
+			WillReturnResult(sqlmock.NewResult(18, 1))
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.NoError(t, err)
+	})
+
+	test.RunWithMockDB(t, "Fail when state encoding fails", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		stateEncoderErr := errors.New("Failed to encode")
+		stateEncoder := func(i interface{}) (bytes []byte, e error) {
+			return nil, stateEncoderErr
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newAggregateProjectionStorage("store_table", "projection_table", stateEncoder, goengine.NopLogger)
+		require.NoError(t, err)
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.Equal(t, stateEncoderErr, err)
+	})
+}

--- a/driver/sql/postgres/projector_stream.go
+++ b/driver/sql/postgres/projector_stream.go
@@ -68,9 +68,14 @@ func NewStreamProjector(
 		stateEncoder = saga.EncodeState
 	}
 
+	storage, err := newStreamProjectionStorage(projection.Name(), projectionTable, stateEncoder, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	executor, err := internalSQL.NewNotificationProjector(
 		db,
-		newStreamProjectionStorage(projection.Name(), projectionTable, stateEncoder, logger),
+		storage,
 		stateDecoder,
 		projection.Handlers(),
 		streamProjectionEventStreamLoader(eventStore, projection.FromStream()),

--- a/driver/sql/postgres/projector_stream_storage_test.go
+++ b/driver/sql/postgres/projector_stream_storage_test.go
@@ -1,0 +1,90 @@
+// +build unit
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/hellofresh/goengine"
+	driverSQL "github.com/hellofresh/goengine/driver/sql"
+	"github.com/hellofresh/goengine/driver/sql/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamProjectionStorage_PersistState(t *testing.T) {
+	mockedProjectionState := "I'm a projection state"
+	notification := &driverSQL.ProjectionNotification{
+		No:          1,
+		AggregateID: "d8490e85-dd22-4c32-9cb0-a29e57949951",
+	}
+	projectionState := driverSQL.ProjectionState{
+		Position:        5,
+		ProjectionState: mockedProjectionState,
+	}
+
+	test.RunWithMockDB(t, "Persist projection state", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		stateEncoderCalls := 0
+		stateEncoder := func(i interface{}) (bytes []byte, e error) {
+			assert.Equal(t, mockedProjectionState, i)
+
+			stateEncoderCalls++
+			return []byte(mockedProjectionState), nil
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newStreamProjectionStorage("my_projection", "projection_table", stateEncoder, goengine.NopLogger)
+		require.NoError(t, err)
+
+		dbMock.ExpectExec("^UPDATE \"projection_table\" SET").
+			WithArgs(5, []byte(mockedProjectionState), "my_projection").
+			WillReturnResult(sqlmock.NewResult(18, 1))
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, stateEncoderCalls)
+	})
+
+	test.RunWithMockDB(t, "Persist projection state (using default encoder)", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		projectionState := driverSQL.ProjectionState{
+			Position:        6,
+			ProjectionState: nil,
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newStreamProjectionStorage("my_projection", "projection_table", nil, goengine.NopLogger)
+		require.NoError(t, err)
+
+		dbMock.ExpectExec("^UPDATE \"projection_table\" SET").
+			WithArgs(6, []byte("{}"), "my_projection").
+			WillReturnResult(sqlmock.NewResult(18, 1))
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.NoError(t, err)
+	})
+
+	test.RunWithMockDB(t, "Fail when state encoding fails", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
+		stateEncoderErr := errors.New("Failed to encode")
+		stateEncoder := func(i interface{}) (bytes []byte, e error) {
+			return nil, stateEncoderErr
+		}
+
+		conn, err := db.Conn(context.Background())
+		require.NoError(t, err)
+
+		storage, err := newStreamProjectionStorage("my_projection", "projection_table", stateEncoder, goengine.NopLogger)
+		require.NoError(t, err)
+
+		err = storage.PersistState(conn, notification, projectionState)
+		assert.Equal(t, stateEncoderErr, err)
+	})
+
+}

--- a/driver/sql/postgres/projector_test.go
+++ b/driver/sql/postgres/projector_test.go
@@ -1,0 +1,38 @@
+// +build unit
+
+package postgres
+
+import (
+	"fmt"
+	"github.com/hellofresh/goengine"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultProjectionStateEncoder(t *testing.T) {
+	t.Run("Only accept nil values as valid", func(t *testing.T) {
+		res, err := defaultProjectionStateEncoder(nil)
+
+		assert.Equal(t, []byte{'{', '}'}, res)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Reject any state this not nil", func(t *testing.T) {
+		var pointer *goengine.Projection
+		testCases := []interface{}{
+			struct{}{},
+			pointer,
+			"",
+			0,
+		}
+
+		for i, v := range testCases {
+			t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+				res, err := defaultProjectionStateEncoder(v)
+
+				assert.Error(t, err)
+				assert.Nil(t, res)
+			})
+		}
+	})
+}


### PR DESCRIPTION
In order to avoid people relying on the state but not providing an encoder we now return an error.