### PR TITLE
Ensure Projection Init is called

### DIFF
--- a/driver/sql/postgres/projector_aggregate.go
+++ b/driver/sql/postgres/projector_aggregate.go
@@ -84,6 +84,7 @@ func NewAggregateProjector(
 	executor, err := internal.NewNotificationProjector(
 		db,
 		storage,
+		projection.Init,
 		stateDecoder,
 		projection.Handlers(),
 		aggregateProjectionEventStreamLoader(eventStore, projection.FromStream(), aggregateTypeName),

--- a/driver/sql/postgres/projector_aggregate_storage.go
+++ b/driver/sql/postgres/projector_aggregate_storage.go
@@ -92,7 +92,7 @@ func newAggregateProjectionStorage(
 		queryAcquireLock: fmt.Sprintf(
 			`WITH new_projection AS (
 			  INSERT INTO %[1]s (aggregate_id, state) SELECT $1, 'null' WHERE NOT EXISTS (
-		    	SELECT * FROM %[1]s WHERE aggregate_id = $1
+		    	SELECT * FROM %[1]s WHERE aggregate_id = $1 LIMIT 1
 			  ) ON CONFLICT DO NOTHING
 			  RETURNING *
 			)
@@ -118,7 +118,7 @@ func (a *aggregateProjectionStorage) LoadOutOfSync(ctx context.Context, conn dri
 	return conn.QueryContext(ctx, a.queryOutOfSyncProjections)
 }
 
-func (a *aggregateProjectionStorage) PersistState(conn *sql.Conn, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) error {
+func (a *aggregateProjectionStorage) PersistState(conn driverSQL.Execer, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) error {
 	encodedState, err := a.projectionStateEncoder(state.ProjectionState)
 	if err != nil {
 		return err

--- a/driver/sql/postgres/projector_aggregate_storage.go
+++ b/driver/sql/postgres/projector_aggregate_storage.go
@@ -14,12 +14,12 @@ import (
 )
 
 func aggregateProjectionEventStreamLoader(eventStore driverSQL.ReadOnlyEventStore, streamName goengine.StreamName, aggregateTypeName string) driverSQL.EventStreamLoader {
-	return func(ctx context.Context, conn *sql.Conn, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) (goengine.EventStream, error) {
+	return func(ctx context.Context, conn *sql.Conn, notification *driverSQL.ProjectionNotification, position int64) (goengine.EventStream, error) {
 		matcher := metadata.NewMatcher()
 		matcher = metadata.WithConstraint(matcher, aggregate.IDKey, metadata.Equals, notification.AggregateID)
 		matcher = metadata.WithConstraint(matcher, aggregate.TypeKey, metadata.Equals, aggregateTypeName)
 
-		return eventStore.LoadWithConnection(ctx, conn, streamName, state.Position+1, nil, matcher)
+		return eventStore.LoadWithConnection(ctx, conn, streamName, position+1, nil, matcher)
 	}
 }
 

--- a/driver/sql/postgres/projector_stream_storage.go
+++ b/driver/sql/postgres/projector_stream_storage.go
@@ -12,8 +12,8 @@ import (
 )
 
 func streamProjectionEventStreamLoader(eventStore driverSQL.ReadOnlyEventStore, streamName goengine.StreamName) driverSQL.EventStreamLoader {
-	return func(ctx context.Context, conn *sql.Conn, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) (goengine.EventStream, error) {
-		return eventStore.LoadWithConnection(ctx, conn, streamName, state.Position+1, nil, nil)
+	return func(ctx context.Context, conn *sql.Conn, notification *driverSQL.ProjectionNotification, position int64) (goengine.EventStream, error) {
+		return eventStore.LoadWithConnection(ctx, conn, streamName, position+1, nil, nil)
 	}
 }
 

--- a/driver/sql/postgres/projector_stream_storage.go
+++ b/driver/sql/postgres/projector_stream_storage.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hellofresh/goengine"
-
 	driverSQL "github.com/hellofresh/goengine/driver/sql"
 )
 
@@ -26,6 +25,7 @@ type streamProjectionStorage struct {
 
 	logger goengine.Logger
 
+	queryCreateProjection    string
 	queryAcquireLock         string
 	queryAcquirePositionLock string
 	queryReleaseLock         string
@@ -62,6 +62,10 @@ func newStreamProjectionStorage(
 		projectionStateEncoder: projectionStateEncoder,
 		logger:                 logger,
 
+		queryCreateProjection: fmt.Sprintf(
+			`INSERT INTO %s (name) VALUES ($1) ON CONFLICT DO NOTHING`,
+			projectionTableQuoted,
+		),
 		queryAcquireLock: fmt.Sprintf(
 			`SELECT pg_try_advisory_lock(%[2]s::regclass::oid::int, no), locked, position, state FROM %[1]s WHERE name = $1`,
 			projectionTableQuoted,
@@ -88,7 +92,12 @@ func newStreamProjectionStorage(
 	}, nil
 }
 
-func (s *streamProjectionStorage) PersistState(conn *sql.Conn, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) error {
+func (s *streamProjectionStorage) CreateProjection(ctx context.Context, conn driverSQL.Execer) error {
+	_, err := conn.ExecContext(ctx, s.queryCreateProjection, s.projectionName)
+	return err
+}
+
+func (s *streamProjectionStorage) PersistState(conn driverSQL.Execer, notification *driverSQL.ProjectionNotification, state driverSQL.ProjectionState) error {
 	encodedState, err := s.projectionStateEncoder(state.ProjectionState)
 	if err != nil {
 		return err

--- a/driver/sql/projection.go
+++ b/driver/sql/projection.go
@@ -55,5 +55,5 @@ type (
 	ProjectionErrorAction int
 
 	// EventStreamLoader loads a event stream based on the provided notification and state
-	EventStreamLoader func(ctx context.Context, conn *sql.Conn, notification *ProjectionNotification, state ProjectionState) (goengine.EventStream, error)
+	EventStreamLoader func(ctx context.Context, conn *sql.Conn, notification *ProjectionNotification, position int64) (goengine.EventStream, error)
 )

--- a/driver/sql/projection.go
+++ b/driver/sql/projection.go
@@ -29,6 +29,9 @@ type (
 		ProjectionState []byte
 	}
 
+	// ProjectionStateInitializer is a func to initialize a ProjectionState.ProjectionState
+	ProjectionStateInitializer func(ctx context.Context) (interface{}, error)
+
 	// ProjectionStateEncoder is a func to marshal the ProjectionState.ProjectionState
 	ProjectionStateEncoder func(interface{}) ([]byte, error)
 
@@ -38,7 +41,7 @@ type (
 	// ProjectionStorage is an interface for handling the projection storage
 	ProjectionStorage interface {
 		// PersistState persists the state of the projection
-		PersistState(conn *sql.Conn, notification *ProjectionNotification, state ProjectionState) error
+		PersistState(conn Execer, notification *ProjectionNotification, state ProjectionState) error
 
 		// Acquire this function is used to acquire the projection and it's projectionState
 		// A projection can only be acquired once and must be released using the returned func


### PR DESCRIPTION
During one of the refactors we lost the Projection Init call.
This init call has been added again to ensure projections can setup there initial state.