### PR TITLE
Welcome GoLang 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.10.x
   - 1.11.x
+  - 1.12.x
   - master
 dist: xenial
 addons:


### PR DESCRIPTION
Since 1.12 is now out we will drop support for 1.10.