### PR TITLE
 Use assert for the test and require for requirements 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   build-tags:
     - unit
+    - integration
   skip-files:
     - driver/inmemory/matcher_gen.go
 

--- a/aggregate/aggregate_test.go
+++ b/aggregate/aggregate_test.go
@@ -49,9 +49,8 @@ func TestIDFromString(t *testing.T) {
 			t.Run(testCase.title, func(t *testing.T) {
 				id, err := aggregate.IDFromString(testCase.input)
 
-				asserts := assert.New(t)
-				asserts.Nil(err)
-				asserts.Equal(testCase.output, id)
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.output, id)
 			})
 		}
 	})
@@ -106,7 +105,7 @@ func TestRecordChange(t *testing.T) {
 		err := aggregate.RecordChange(root, domainEvent)
 
 		// Check that the change was recorded
-		asserts.Empty(err, "No error should be returned")
+		asserts.NoError(err)
 	})
 
 	t.Run("Check required arguments", func(t *testing.T) {

--- a/aggregate/aggregate_type_test.go
+++ b/aggregate/aggregate_type_test.go
@@ -20,7 +20,7 @@ func TestType(t *testing.T) {
 		aggregateType, err := aggregate.NewType("mock", mockInitiator)
 
 		asserts := assert.New(t)
-		if !asserts.Empty(err, "No error should be returned") {
+		if !asserts.NoError(err, "No error should be returned") {
 			return
 		}
 		asserts.NotEmpty(aggregateType, "A aggregate.Type should be returned")
@@ -61,9 +61,9 @@ func TestType(t *testing.T) {
 		t.Run("CreateInstance", func(t *testing.T) {
 			newInstance := aggregateType.CreateInstance()
 
-			asserts := assert.New(t)
-			asserts.NotNil(newInstance, "Expect the instance to not be empty")
-			asserts.True(
+			assert.NotNil(t, newInstance, "Expect the instance to not be empty")
+			assert.True(
+				t,
 				aggregateType.IsImplementedBy(newInstance),
 				"Expected new instance of it's type",
 			)

--- a/driver/generic/query_executor_test.go
+++ b/driver/generic/query_executor_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/driver/generic"
 	"github.com/hellofresh/goengine/driver/inmemory"
 	"github.com/hellofresh/goengine/metadata"
 	"github.com/hellofresh/goengine/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewQueryExecutor(t *testing.T) {
@@ -34,9 +34,8 @@ func TestNewQueryExecutor(t *testing.T) {
 
 		executor, err := generic.NewQueryExecutor(store, "test", registry, query, 100)
 
-		asserts := assert.New(t)
-		asserts.NotNil(executor)
-		asserts.NoError(err)
+		assert.NotNil(t, executor)
+		assert.NoError(t, err)
 	})
 
 	t.Run("invalid arguments", func(t *testing.T) {
@@ -118,7 +117,6 @@ func TestQueryExecutor_Run(t *testing.T) {
 			numbers: []int{1, 2, 3},
 		}
 
-		asserts := assert.New(t)
 		eventBatch1, err := inmemory.NewEventStream(
 			[]goengine.Message{
 				mockMessageWithPayload(myEvent{1}, map[string]interface{}{}),
@@ -126,9 +124,7 @@ func TestQueryExecutor_Run(t *testing.T) {
 			},
 			[]int64{1, 2},
 		)
-		if !asserts.NoError(err) {
-			return
-		}
+		require.NoError(t, err)
 
 		eventBatch2, err := inmemory.NewEventStream(
 			[]goengine.Message{
@@ -136,9 +132,7 @@ func TestQueryExecutor_Run(t *testing.T) {
 			},
 			[]int64{3},
 		)
-		if !asserts.NoError(err) {
-			return
-		}
+		require.NoError(t, err)
 
 		var streamName goengine.StreamName = "event_stream"
 
@@ -181,14 +175,12 @@ func TestQueryExecutor_Run(t *testing.T) {
 		}).MinTimes(1)
 
 		executor, err := generic.NewQueryExecutor(store, streamName, registry, query, queryBatchSize)
-		if !asserts.NoError(err) {
-			asserts.FailNow("failed to create executor")
-		}
+		require.NoError(t, err)
 
 		finalState, err := executor.Run(ctx)
 
-		asserts.Equal(expectedState, finalState)
-		asserts.NoError(err)
+		assert.Equal(t, expectedState, finalState)
+		assert.NoError(t, err)
 	})
 }
 

--- a/driver/inmemory/eventstream_test.go
+++ b/driver/inmemory/eventstream_test.go
@@ -42,15 +42,15 @@ func TestEventStream(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.title, func(t *testing.T) {
-			asserts := assert.New(t)
-
 			stream, err := inmemory.NewEventStream(testCase.messages, testCase.messageNumbers)
-			require.NoError(t, err)
+
+			asserts := assert.New(t)
+			asserts.NoError(err)
 			asserts.NotNil(stream)
 
 			messages, messageNumbers, err := goengine.ReadEventStream(stream)
-			require.NoError(t, err)
-			require.NoError(t, stream.Err(), "no exception was expected while reading the stream")
+			asserts.NoError(err)
+			asserts.NoError(stream.Err(), "no exception was expected while reading the stream")
 
 			asserts.Equal(testCase.messages, messages)
 			asserts.Equal(testCase.messageNumbers, messageNumbers)
@@ -67,29 +67,21 @@ func TestEventStream(t *testing.T) {
 	}
 
 	t.Run("invalid arguments", func(t *testing.T) {
-		asserts := assert.New(t)
-
 		stream, err := inmemory.NewEventStream(nil, []int64{1})
-		if asserts.Error(err) {
-			asserts.Equal(err, inmemory.ErrMessageNumberCountMismatch)
-		}
-		asserts.Nil(stream)
+
+		assert.Equal(t, err, inmemory.ErrMessageNumberCountMismatch)
+		assert.Nil(t, stream)
 	})
 
 	t.Run("iteration must start before a message can be fetched", func(t *testing.T) {
-		asserts := assert.New(t)
-
 		stream, err := inmemory.NewEventStream([]goengine.Message{}, []int64{})
-		if !asserts.NoError(err) {
-			return
-		}
-		asserts.NotNil(stream)
+		require.NoError(t, err)
 
 		msg, msgNumber, err := stream.Message()
+
+		asserts := assert.New(t)
+		asserts.Equal(inmemory.ErrEventStreamNotStarted, err)
 		asserts.Nil(msg)
 		asserts.Empty(msgNumber)
-		if asserts.Error(err) {
-			asserts.Equal(inmemory.ErrEventStreamNotStarted, err)
-		}
 	})
 }

--- a/driver/inmemory/matcher_test.go
+++ b/driver/inmemory/matcher_test.go
@@ -49,7 +49,7 @@ func TestNewMetadataMatcher(t *testing.T) {
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, log.Wrap(logger))
 
 				asserts := assert.New(t)
-				asserts.Nil(err)
+				asserts.NoError(err)
 				asserts.IsType((*inmemory.MetadataMatcher)(nil), matcher)
 				asserts.Len(loggerHook.Entries, 0)
 			})
@@ -92,10 +92,7 @@ func TestNewMetadataMatcher(t *testing.T) {
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, log.Wrap(logger))
 
 				asserts := assert.New(t)
-				if !asserts.IsType(inmemory.IncompatibleMatcherError{}, err) {
-					return
-				}
-
+				asserts.IsType(inmemory.IncompatibleMatcherError{}, err)
 				asserts.Equal("goengine: incompatible metadata.Matcher\n"+testCase.expectedError, err.Error())
 				asserts.Nil(matcher)
 				asserts.Len(loggerHook.Entries, 0)
@@ -161,13 +158,13 @@ func TestMetadataMatcher_Matches(t *testing.T) {
 
 		for _, testCase := range testCases {
 			t.Run(testCase.title, func(t *testing.T) {
-				asserts := assert.New(t)
 				logger, loggerHook := test.NewNullLogger()
 
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, log.Wrap(logger))
-				if asserts.Nil(err) {
-					asserts.True(matcher.Matches(testCase.data))
-				}
+
+				asserts := assert.New(t)
+				asserts.NoError(err)
+				asserts.True(matcher.Matches(testCase.data))
 				asserts.Len(loggerHook.Entries, 0)
 			})
 		}
@@ -193,13 +190,13 @@ func TestMetadataMatcher_Matches(t *testing.T) {
 
 		for _, testCase := range testCases {
 			t.Run(testCase.title, func(t *testing.T) {
-				asserts := assert.New(t)
 				logger, loggerHook := test.NewNullLogger()
 
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, log.Wrap(logger))
-				if asserts.Nil(err) {
-					asserts.False(matcher.Matches(testCase.data))
-				}
+
+				asserts := assert.New(t)
+				asserts.NoError(err)
+				asserts.False(matcher.Matches(testCase.data))
 				asserts.Len(loggerHook.Entries, 0)
 			})
 		}
@@ -233,31 +230,31 @@ func TestMetadataMatcher_Matches(t *testing.T) {
 
 		for _, testCase := range errorTestCases {
 			t.Run(testCase.title, func(t *testing.T) {
-				asserts := assert.New(t)
 				logger, loggerHook := test.NewNullLogger()
 
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, log.Wrap(logger))
-				if asserts.Nil(err) {
-					asserts.False(matcher.Matches(testCase.data))
 
-					logEntries := loggerHook.AllEntries()
-					if asserts.Len(logEntries, 1) && asserts.Contains(logEntries[0].Data, logrus.ErrorKey) {
-						entry := logEntries[0]
-						asserts.Equal(logrus.WarnLevel, entry.Level)
-						asserts.Equal(testCase.expectedError, entry.Data[logrus.ErrorKey])
-					}
+				asserts := assert.New(t)
+				asserts.NoError(err)
+				asserts.False(matcher.Matches(testCase.data))
+
+				logEntries := loggerHook.AllEntries()
+				if asserts.Len(logEntries, 1) {
+					entry := logEntries[0]
+
+					asserts.Contains(entry.Data, logrus.ErrorKey)
+					asserts.Equal(logrus.WarnLevel, entry.Level)
+					asserts.Equal(testCase.expectedError, entry.Data[logrus.ErrorKey])
 				}
 			})
 		}
 
 		for _, testCase := range errorTestCases {
 			t.Run(testCase.title+"(without logger)", func(t *testing.T) {
-				asserts := assert.New(t)
-
 				matcher, err := inmemory.NewMetadataMatcher(testCase.matcher, nil)
-				if asserts.Nil(err) {
-					asserts.False(matcher.Matches(testCase.data))
-				}
+
+				assert.NoError(t, err)
+				assert.False(t, matcher.Matches(testCase.data))
 			})
 		}
 	})

--- a/driver/inmemory/payload_registry_test.go
+++ b/driver/inmemory/payload_registry_test.go
@@ -32,16 +32,12 @@ func TestPayloadRegistry(t *testing.T) {
 	}
 
 	registry := &inmemory.PayloadRegistry{}
-	if !assert.NotNil(t, registry) {
-		return
-	}
 
 	t.Run("register payloads", func(t *testing.T) {
-		asserts := assert.New(t)
 		for _, testCase := range testCases {
 			err := registry.RegisterPayload(testCase.payloadType, testCase.payload)
 
-			asserts.NoError(err)
+			assert.NoError(t, err)
 		}
 	})
 
@@ -50,32 +46,24 @@ func TestPayloadRegistry(t *testing.T) {
 			t.Run(tc.title, func(t *testing.T) {
 				name, err := registry.ResolveName(tc.payload)
 
-				asserts := assert.New(t)
-				if asserts.NoError(err) {
-					asserts.Equal(tc.payloadType, name)
-				}
+				assert.Equal(t, tc.payloadType, name)
+				assert.NoError(t, err)
 			})
 		}
 	})
 
 	t.Run("duplicate type registry", func(t *testing.T) {
-		asserts := assert.New(t)
 		for _, testCase := range testCases {
 			err := registry.RegisterPayload(testCase.payloadType, testCase.payload)
 
-			if asserts.Error(err) {
-				asserts.Equal(inmemory.ErrDuplicatePayloadType, err)
-			}
+			assert.Equal(t, inmemory.ErrDuplicatePayloadType, err)
 		}
 	})
 
 	t.Run("unknown type", func(t *testing.T) {
 		name, err := registry.ResolveName(struct{}{})
 
-		asserts := assert.New(t)
-		if asserts.Error(err) {
-			asserts.Equal(inmemory.ErrUnknownPayloadType, err)
-		}
-		asserts.Empty(name)
+		assert.Equal(t, inmemory.ErrUnknownPayloadType, err)
+		assert.Empty(t, name)
 	})
 }

--- a/driver/sql/postgres/eventstore_test.go
+++ b/driver/sql/postgres/eventstore_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/golang/mock/gomock"
 	"github.com/hellofresh/goengine"
 	driverSQL "github.com/hellofresh/goengine/driver/sql"
 	"github.com/hellofresh/goengine/driver/sql/internal/test"
@@ -99,9 +98,7 @@ func TestEventStore_Create(t *testing.T) {
 		store := createEventStore(t, db, &mocks.MessagePayloadConverter{})
 
 		err := store.Create(context.Background(), "orders")
-		if assert.Error(t, err) {
-			assert.Equal(t, expectedError, err)
-		}
+		assert.Equal(t, expectedError, err)
 	})
 	test.RunWithMockDB(t, "Empty stream name", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
 		store := createEventStore(t, db, &mocks.MessagePayloadConverter{})
@@ -119,9 +116,7 @@ func TestEventStore_Create(t *testing.T) {
 		store := createEventStore(t, db, &mocks.MessagePayloadConverter{})
 
 		err := store.Create(context.Background(), "orders")
-		if assert.Error(t, err) {
-			assert.Equal(t, postgres.ErrTableAlreadyExists, err)
-		}
+		assert.Equal(t, postgres.ErrTableAlreadyExists, err)
 	})
 
 	test.RunWithMockDB(t, "No queries in strategy", func(t *testing.T, db *sql.DB, dbMock sqlmock.Sqlmock) {
@@ -135,14 +130,10 @@ func TestEventStore_Create(t *testing.T) {
 		strategy.EXPECT().CreateSchema("events_orders").Return([]string{}).AnyTimes()
 
 		store, err := postgres.NewEventStore(strategy, db, &mockSQL.MessageFactory{}, nil)
-		if !asserts.NoError(err) {
-			t.Fail()
-		}
+		require.NoError(t, err)
 
 		err = store.Create(context.Background(), "orders")
-		if asserts.Error(err) {
-			asserts.Equal(postgres.ErrNoCreateTableQueries, err)
-		}
+		asserts.Equal(postgres.ErrNoCreateTableQueries, err)
 	})
 }
 
@@ -241,15 +232,10 @@ func TestEventStore_AppendTo(t *testing.T) {
 		persistenceStrategy.EXPECT().ColumnNames().Return([]string{"event_id", "event_name"}).AnyTimes()
 
 		store, err := postgres.NewEventStore(persistenceStrategy, db, &mockSQL.MessageFactory{}, nil)
-		asserts := assert.New(t)
-		if !asserts.NoError(err) {
-			t.Fail()
-		}
+		require.NoError(t, err)
 
 		err = store.AppendTo(context.Background(), "orders", messages)
-		if asserts.Error(err) {
-			asserts.Equal(expectedError, err)
-		}
+		assert.Equal(t, expectedError, err)
 	})
 }
 
@@ -323,7 +309,8 @@ func TestEventStore_Load(t *testing.T) {
 					testCase.count,
 					testCase.matcher(),
 				)
-				require.NoError(t, err)
+
+				assert.NoError(t, err)
 				assert.Equal(t, expectedStream, stream)
 			})
 		}
@@ -371,9 +358,8 @@ func TestEventStore_Load(t *testing.T) {
 				require.NoError(t, err)
 
 				stream, err := store.Load(context.Background(), "event_stream", 1, nil, nil)
-				if assert.Error(t, err) {
-					assert.Equal(t, testCase.expectedError, err)
-				}
+
+				assert.Equal(t, testCase.expectedError, err)
 				assert.Nil(t, stream)
 			})
 		}
@@ -408,17 +394,11 @@ func mockMessages(ctrl *gomock.Controller) (*mocks.MessagePayloadConverter, []go
 }
 
 func createEventStore(t *testing.T, db *sql.DB, converter goengine.MessagePayloadConverter) *postgres.EventStore {
-	asserts := assert.New(t)
-
 	persistenceStrategy, err := strategyPostgres.NewSingleStreamStrategy(converter)
-	if !asserts.NoError(err) {
-		t.Fail()
-	}
+	require.NoError(t, err)
 
 	store, err := postgres.NewEventStore(persistenceStrategy, db, &mockSQL.MessageFactory{}, nil)
-	if !asserts.NoError(err) {
-		t.Fail()
-	}
+	require.NoError(t, err)
 
 	return store
 }

--- a/eventstore_test.go
+++ b/eventstore_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/mocks"
 	"github.com/stretchr/testify/assert"
@@ -37,10 +36,9 @@ func TestReadEventStream(t *testing.T) {
 
 		messages, numbers, err := goengine.ReadEventStream(stream)
 
-		if assert.NoError(t, err) {
-			assert.Equal(t, mockedMessages, messages)
-			assert.Equal(t, []int64{1, 2, 3, 4}, numbers)
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, mockedMessages, messages)
+		assert.Equal(t, []int64{1, 2, 3, 4}, numbers)
 	})
 
 	t.Run("Error while iterating", func(t *testing.T) {
@@ -56,9 +54,7 @@ func TestReadEventStream(t *testing.T) {
 		messages, numbers, err := goengine.ReadEventStream(stream)
 
 		asserts := assert.New(t)
-		if asserts.Error(err) {
-			asserts.Equal(expectedError, err)
-		}
+		asserts.Equal(expectedError, err)
 		asserts.Empty(messages)
 		asserts.Empty(numbers)
 	})
@@ -86,9 +82,7 @@ func TestReadEventStream(t *testing.T) {
 		messages, numbers, err := goengine.ReadEventStream(stream)
 
 		asserts := assert.New(t)
-		if asserts.Error(err) {
-			asserts.Equal(expectedError, err)
-		}
+		asserts.Equal(expectedError, err)
 		asserts.Empty(numbers)
 		asserts.Empty(messages)
 	})

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -181,9 +181,8 @@ func TestMetadata_MarshalJSON(t *testing.T) {
 
 			mJSON, err := json.Marshal(m)
 
-			asserts := assert.New(t)
-			asserts.JSONEq(testCase.json, string(mJSON))
-			asserts.Nil(err)
+			assert.JSONEq(t, testCase.json, string(mJSON))
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -197,9 +196,8 @@ func TestJSONMetadata_MarshalJSON(t *testing.T) {
 
 			mJSON, err := json.Marshal(m)
 
-			asserts := assert.New(t)
-			asserts.JSONEq(testCase.json, string(mJSON))
-			asserts.Nil(err)
+			assert.JSONEq(t, testCase.json, string(mJSON))
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -210,10 +208,9 @@ func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
 			var m metadata.JSONMetadata
 			err := json.Unmarshal([]byte(testCase.json), &m)
 
-			asserts := assert.New(t)
 			// Need to use AsMap otherwise we can have inconsistent tests results.
-			asserts.Equal(testCase.metadata().AsMap(), m.Metadata.AsMap())
-			asserts.NoError(err)
+			assert.Equal(t, testCase.metadata().AsMap(), m.Metadata.AsMap())
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/strategy/json/payload_transformer_test.go
+++ b/strategy/json/payload_transformer_test.go
@@ -166,14 +166,12 @@ func TestJSONPayloadTransformer_CreatePayload(t *testing.T) {
 
 				factory := strategyJSON.NewPayloadTransformer()
 				err := factory.RegisterPayload(testCase.payloadType, testCase.payloadInitiator)
-				if !asserts.Nil(err) {
-					return
-				}
+				require.NoError(t, err)
 
-				payload, err := factory.CreatePayload(testCase.payloadType, testCase.payloadData)
+				res, err := factory.CreatePayload(testCase.payloadType, testCase.payloadData)
 
-				asserts.EqualValues(testCase.expectedData, payload)
-				asserts.Nil(err)
+				asserts.EqualValues(testCase.expectedData, res)
+				asserts.NoError(err)
 			})
 		}
 	})
@@ -204,11 +202,10 @@ func TestJSONPayloadTransformer_CreatePayload(t *testing.T) {
 		for _, testCase := range testCases {
 			t.Run(testCase.title, func(t *testing.T) {
 				factory := strategyJSON.NewPayloadTransformer()
-				payload, err := factory.CreatePayload(testCase.payloadType, testCase.payloadData)
+				res, err := factory.CreatePayload(testCase.payloadType, testCase.payloadData)
 
-				asserts := assert.New(t)
-				asserts.Equal(testCase.expectedError, err)
-				asserts.Nil(payload)
+				assert.Equal(t, testCase.expectedError, err)
+				assert.Nil(t, res)
 			})
 		}
 	})
@@ -246,9 +243,8 @@ func TestJSONPayloadTransformer_CreatePayload(t *testing.T) {
 
 				res, err := factory.CreatePayload("tests", testCase.payloadData)
 
-				asserts := assert.New(t)
-				asserts.IsType((*json.SyntaxError)(nil), err)
-				asserts.Nil(res)
+				assert.IsType(t, (*json.SyntaxError)(nil), err)
+				assert.Nil(t, res)
 			})
 		}
 	})

--- a/test/projector_aggregate_integration_test.go
+++ b/test/projector_aggregate_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hellofresh/goengine/driver/sql"
 	driverSQL "github.com/hellofresh/goengine/driver/sql"
 	"github.com/hellofresh/goengine/driver/sql/postgres"
-	pq "github.com/hellofresh/goengine/extension/pq"
+	"github.com/hellofresh/goengine/extension/pq"
 	strategyPostgres "github.com/hellofresh/goengine/strategy/json/sql/postgres"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -288,10 +288,7 @@ func (s *aggregateProjectorTestSuite) TestRun() {
 
 func (s *aggregateProjectorTestSuite) assertAggregateProjectionStates(expectedProjections map[aggregate.ID]projectionInfo) {
 	stmt, err := s.DB().Prepare(`SELECT aggregate_id, position, state FROM agg_projections`)
-	if err != nil {
-		s.T().Fatal(err)
-		return
-	}
+	s.Require().NoError(err)
 
 	var result map[aggregate.ID]projectionInfo
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
In order to remove some code and add some consistency we now use assert to assert the results of the actual tests.
require is no used for any required parts of the tests.

This PR also fixes some broken tests as a nice side effect.