### PR TITLE
Use easyjson for metadata unmarshaling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -49,6 +49,19 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5bf23f15fd4550fa19e9fbc8e9fd2e254444a01f4644ad835b5389d1f7d91077"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    ".",
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = "UT"
+  revision = "6243d8e04c3f819e79757e8bc3faa15c3cb27003"
+
+[[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -146,6 +159,8 @@
     "github.com/golang/mock/mockgen",
     "github.com/google/uuid",
     "github.com/lib/pq",
+    "github.com/mailru/easyjson",
+    "github.com/mailru/easyjson/jlexer",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/sirupsen/logrus/hooks/test",

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"encoding/json"
 
+	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
 )
 
@@ -98,25 +99,24 @@ func (v *valueData) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.AsMap())
 }
 
-// JSONMetadata is a special struct to UnmarshalJSON metadata
-type JSONMetadata struct {
+func UnmarshalJSON(json []byte) (Metadata, error) {
+	wrapper := jsonMetadata{
+		Metadata: New(),
+	}
+
+	if err := easyjson.Unmarshal(json, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.Metadata, nil
+}
+
+// jsonMetadata is a special struct to UnmarshalJSON metadata
+type jsonMetadata struct {
 	Metadata Metadata
 }
 
-var (
-	// Ensure JSONMetadata implements the json.Unmarshaler interface
-	_ json.Unmarshaler = &JSONMetadata{}
-)
-
-// UnmarshalJSON unmarshal the json into Metdadata
-func (j *JSONMetadata) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	j.UnmarshalEasyJSON(&r)
-	return r.Error()
-}
-
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (j *JSONMetadata) UnmarshalEasyJSON(in *jlexer.Lexer) {
+func (j *jsonMetadata) UnmarshalEasyJSON(in *jlexer.Lexer) {
 	metadata := New()
 
 	isTopLevel := in.IsStart()

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -104,20 +104,9 @@ type JSONMetadata struct {
 }
 
 var (
-	// Ensure JSONMetadata implements the json.Marshaler interface
-	_ json.Marshaler = &JSONMetadata{}
 	// Ensure JSONMetadata implements the json.Unmarshaler interface
 	_ json.Unmarshaler = &JSONMetadata{}
 )
-
-// MarshalJSON returns a json representation of the wrapped Metadata
-func (j JSONMetadata) MarshalJSON() ([]byte, error) {
-	if j.Metadata == nil {
-		j.Metadata = New()
-	}
-
-	return json.Marshal(j.Metadata)
-}
 
 // UnmarshalJSON unmarshal the json into Metdadata
 func (j *JSONMetadata) UnmarshalJSON(data []byte) error {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -212,21 +212,6 @@ func TestMetadata_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestJSONMetadata_MarshalJSON(t *testing.T) {
-	for _, testCase := range jsonTestCases {
-		t.Run(testCase.title, func(t *testing.T) {
-			m := metadata.JSONMetadata{
-				Metadata: testCase.metadata(),
-			}
-
-			mJSON, err := json.Marshal(m)
-
-			assert.JSONEq(t, testCase.json, string(mJSON))
-			assert.NoError(t, err)
-		})
-	}
-}
-
 func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
 	for _, testCase := range jsonTestCases {
 		t.Run(testCase.title, func(t *testing.T) {

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hellofresh/goengine/metadata"
+	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -247,6 +248,19 @@ func BenchmarkJSONMetadata_UnmarshalJSON(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var m metadata.JSONMetadata
 		err := json.Unmarshal(payload, &m)
+		if err != nil {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkJSONMetadata_UnmarshalEasyJSON(b *testing.B) {
+	payload := []byte(`{"_aggregate_id": "b9ebca7a-c1eb-40dd-94a4-fac7c5e84fb5", "_aggregate_type": "bank_account", "_aggregate_version": 1}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var m metadata.JSONMetadata
+		err := easyjson.Unmarshal(payload, &m)
 		if err != nil {
 			b.Fail()
 		}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hellofresh/goengine/metadata"
-	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -215,12 +214,11 @@ func TestMetadata_MarshalJSON(t *testing.T) {
 func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
 	for _, testCase := range jsonTestCases {
 		t.Run(testCase.title, func(t *testing.T) {
-			var m metadata.JSONMetadata
-			err := json.Unmarshal([]byte(testCase.json), &m)
+			m, err := metadata.UnmarshalJSON([]byte(testCase.json))
 
 			// Need to use AsMap otherwise we can have inconsistent tests results.
 			if assert.NoError(t, err) {
-				assert.Equal(t, testCase.metadata().AsMap(), m.Metadata.AsMap())
+				assert.Equal(t, testCase.metadata().AsMap(), m.AsMap())
 			}
 		})
 	}
@@ -231,21 +229,7 @@ func BenchmarkJSONMetadata_UnmarshalJSON(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		var m metadata.JSONMetadata
-		err := json.Unmarshal(payload, &m)
-		if err != nil {
-			b.Fail()
-		}
-	}
-}
-
-func BenchmarkJSONMetadata_UnmarshalEasyJSON(b *testing.B) {
-	payload := []byte(`{"_aggregate_id": "b9ebca7a-c1eb-40dd-94a4-fac7c5e84fb5", "_aggregate_type": "bank_account", "_aggregate_version": 1}`)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		var m metadata.JSONMetadata
-		err := easyjson.Unmarshal(payload, &m)
+		_, err := metadata.UnmarshalJSON(payload)
 		if err != nil {
 			b.Fail()
 		}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -172,6 +172,30 @@ var jsonTestCases = []struct {
 			"another": "value"
 		}`,
 	},
+	{
+		"metadata with 'complex' json",
+		func() metadata.Metadata {
+			m := metadata.New()
+			m = metadata.WithValue(m, "test", nil)
+			m = metadata.WithValue(m, "another", "value")
+			m = metadata.WithValue(m, "arr", []interface{}{"a", "b", "c"})
+			m = metadata.WithValue(m, "arrInArr", []interface{}{"a", []interface{}{"b"}})
+			m = metadata.WithValue(m, "obj", map[string]interface{}{"a": float64(1)})
+			m = metadata.WithValue(m, "objInObj", map[string]interface{}{
+				"a": float64(1),
+				"b": map[string]interface{}{"a": float64(2)},
+			})
+			return m
+		},
+		`{
+			"test": null,
+			"another": "value",
+			"arr": [ "a", "b", "c" ],
+			"arrInArr": [ "a", [ "b" ] ],
+			"obj": { "a": 1 },
+			"objInObj": { "a": 1, "b": {"a": 2} }
+		}`,
+	},
 }
 
 func TestMetadata_MarshalJSON(t *testing.T) {
@@ -209,8 +233,22 @@ func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
 			err := json.Unmarshal([]byte(testCase.json), &m)
 
 			// Need to use AsMap otherwise we can have inconsistent tests results.
-			assert.Equal(t, testCase.metadata().AsMap(), m.Metadata.AsMap())
-			assert.NoError(t, err)
+			if assert.NoError(t, err) {
+				assert.Equal(t, testCase.metadata().AsMap(), m.Metadata.AsMap())
+			}
 		})
+	}
+}
+
+func BenchmarkJSONMetadata_UnmarshalJSON(b *testing.B) {
+	payload := []byte(`{"_aggregate_id": "b9ebca7a-c1eb-40dd-94a4-fac7c5e84fb5", "_aggregate_type": "bank_account", "_aggregate_version": 1}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var m metadata.JSONMetadata
+		err := json.Unmarshal(payload, &m)
+		if err != nil {
+			b.Fail()
+		}
 	}
 }

--- a/strategy/json/sql/message_factory_aggregate.go
+++ b/strategy/json/sql/message_factory_aggregate.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hellofresh/goengine/aggregate"
 	driverSQL "github.com/hellofresh/goengine/driver/sql"
 	"github.com/hellofresh/goengine/metadata"
-	"github.com/mailru/easyjson"
 )
 
 // Ensure that AggregateChangedFactory satisfies the MessageFactory interface
@@ -78,11 +77,10 @@ func (a *aggregateChangedEventStream) Message() (goengine.Message, int64, error)
 		return nil, 0, err
 	}
 
-	metadataWrapper := metadata.JSONMetadata{Metadata: metadata.New()}
-	if err := easyjson.Unmarshal(jsonMetadata, &metadataWrapper); err != nil {
+	meta, err := metadata.UnmarshalJSON(jsonMetadata)
+	if err != nil {
 		return nil, 0, err
 	}
-	meta := metadataWrapper.Metadata
 
 	payload, err := a.payloadFactory.CreatePayload(eventName, jsonPayload)
 	if err != nil {

--- a/strategy/json/sql/message_factory_aggregate.go
+++ b/strategy/json/sql/message_factory_aggregate.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/hellofresh/goengine/aggregate"
 	driverSQL "github.com/hellofresh/goengine/driver/sql"
 	"github.com/hellofresh/goengine/metadata"
+	"github.com/mailru/easyjson"
 )
 
 // Ensure that AggregateChangedFactory satisfies the MessageFactory interface
@@ -79,7 +79,7 @@ func (a *aggregateChangedEventStream) Message() (goengine.Message, int64, error)
 	}
 
 	metadataWrapper := metadata.JSONMetadata{Metadata: metadata.New()}
-	if err := json.Unmarshal(jsonMetadata, &metadataWrapper); err != nil {
+	if err := easyjson.Unmarshal(jsonMetadata, &metadataWrapper); err != nil {
 		return nil, 0, err
 	}
 	meta := metadataWrapper.Metadata

--- a/strategy/json/sql/message_factory_aggregate_test.go
+++ b/strategy/json/sql/message_factory_aggregate_test.go
@@ -164,7 +164,7 @@ func TestAggregateChangedFactory_CreateFromRows(t *testing.T) {
 
 					return mockRows, mocks.NewMessagePayloadFactory(ctrl)
 				},
-				"unexpected end of JSON input",
+				"parse error: expected { near offset 1 of ''",
 			},
 			{
 				"bad payload",


### PR DESCRIPTION
This PR changes the way metadata is  json unmarshalled in order to get a nice speed and memory optimization.

We started with the baseline benchmark:
```
BenchmarkJSONMetadata_UnmarshalJSON-4   	  300000	      4313 ns/op	    1208 B/op	      29 allocs/op
```
And after changing to easyjson and removing the JSONMetadata struct ended up with:
```
BenchmarkJSONMetadata_UnmarshalJSON-4   	 2000000	       615 ns/op	     256 B/op	       9 allocs/op
```