### PR TITLE
Improve JSON Marshalling and Unmarshalling

### DIFF
--- a/aggregate/changed.go
+++ b/aggregate/changed.go
@@ -91,16 +91,14 @@ func (a *Changed) Metadata() metadata.Metadata {
 }
 
 // WithMetadata Returns new instance of the change with key and value added to metadata
-func (a *Changed) WithMetadata(key string, value interface{}) goengine.Message {
-	newAggregateChanged := *a
-	newAggregateChanged.metadata = metadata.WithValue(a.metadata, key, value)
+func (a Changed) WithMetadata(key string, value interface{}) goengine.Message {
+	a.metadata = metadata.WithValue(a.metadata, key, value)
 
-	return &newAggregateChanged
+	return &a
 }
 
-func (a *Changed) withVersion(version uint) *Changed {
-	newAggregateChanged := *a
-	newAggregateChanged.version = version
+func (a Changed) withVersion(version uint) *Changed {
+	a.version = version
 
-	return &newAggregateChanged
+	return &a
 }

--- a/aggregate/changed_test.go
+++ b/aggregate/changed_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/aggregate"
 	"github.com/hellofresh/goengine/metadata"
@@ -126,4 +128,23 @@ func TestReconstituteChange(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestChanged_WithMetadata(t *testing.T) {
+	expectedMetadata := metadata.WithValue(metadata.New(), "test", "value")
+	msg, err := aggregate.ReconstituteChange(
+		aggregate.GenerateID(),
+		goengine.GenerateUUID(),
+		struct{}{},
+		metadata.New(),
+		time.Now(),
+		1,
+	)
+	require.NoError(t, err)
+
+	msgWithTest := msg.WithMetadata("test", "value")
+
+	assert.Equal(t, expectedMetadata, msgWithTest.Metadata())
+	assert.Equal(t, metadata.New(), msg.Metadata(), "Original metadata should not be changed")
+	assert.NotEqual(t, msg, msgWithTest, "Origional changed message should not be changed")
 }

--- a/driver/sql/projection.go
+++ b/driver/sql/projection.go
@@ -87,9 +87,9 @@ func (p *ProjectionNotification) UnmarshalEasyJSON(in *jlexer.Lexer) {
 		}
 		switch key {
 		case "no":
-			p.No = int64(in.Int64())
+			p.No = in.Int64()
 		case "aggregate_id":
-			p.AggregateID = string(in.String())
+			p.AggregateID = in.String()
 		default:
 			in.SkipRecursive()
 		}

--- a/driver/sql/projection.go
+++ b/driver/sql/projection.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/hellofresh/goengine"
+	"github.com/mailru/easyjson/jlexer"
 )
 
 type (
@@ -57,3 +58,45 @@ type (
 	// EventStreamLoader loads a event stream based on the provided notification and state
 	EventStreamLoader func(ctx context.Context, conn *sql.Conn, notification *ProjectionNotification, position int64) (goengine.EventStream, error)
 )
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (p *ProjectionNotification) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	p.UnmarshalEasyJSON(&r)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (p *ProjectionNotification) UnmarshalEasyJSON(in *jlexer.Lexer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeString()
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "no":
+			p.No = int64(in.Int64())
+		case "aggregate_id":
+			p.AggregateID = string(in.String())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}

--- a/extension/pq/listener.go
+++ b/extension/pq/listener.go
@@ -2,13 +2,13 @@ package pq
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/driver/sql"
 	"github.com/lib/pq"
+	"github.com/mailru/easyjson"
 )
 
 // Ensure Listener implements sql.Listener
@@ -138,7 +138,7 @@ func (s *Listener) unmarshalNotification(n *pq.Notification) *sql.ProjectionNoti
 	}
 
 	notification := &sql.ProjectionNotification{}
-	if err := json.Unmarshal([]byte(n.Extra), notification); err != nil {
+	if err := easyjson.Unmarshal([]byte(n.Extra), notification); err != nil {
 		logger.WithError(err).Error("received invalid notification data")
 		return nil
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -3,19 +3,31 @@ package metadata
 import (
 	"encoding/json"
 
+	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jlexer"
+	"github.com/mailru/easyjson/jwriter"
+	"github.com/pkg/errors"
 )
 
-// Metadata is an immutable map[string]interface{} implementation
-type Metadata interface {
-	// Value returns the value associated with this context for key, or nil
-	// if no value is associated with key. Successive calls to Value with
-	// the same key returns the same result.
-	Value(key string) interface{}
+type (
+	// Metadata is an immutable map[string]interface{} implementation
+	Metadata interface {
+		// Value returns the value associated with this context for key, or nil
+		// if no value is associated with key. Successive calls to Value with
+		// the same key returns the same result.
+		Value(key string) interface{}
 
-	// AsMap return the Metadata as a map[string]interface{}
-	AsMap() map[string]interface{}
-}
+		// AsMap return the Metadata as a map[string]interface{}
+		AsMap() map[string]interface{}
+	}
+
+	// jsonMarshaler is an interface used to speed up the json marshalling process
+	jsonMarshaler interface {
+		// MarshalJSONKeyValue writes the Metadata Key and Value and all it's parent Key Value pairs into the writer
+		// If last is true it MUST omit the `,` from the last Key Value pair
+		MarshalJSONKeyValue(out *jwriter.Writer, last bool)
+	}
+)
 
 // New return a new Metadata instance without any information
 func New() Metadata {
@@ -43,8 +55,12 @@ type emptyData int
 var (
 	// Ensure emptyData implements the Metadata interface
 	_ Metadata = new(emptyData)
-	// Ensure valueData implements the json.Marshaler interface
+	// Ensure valueData implements the jsonMarshaler interface
+	_ jsonMarshaler = new(emptyData)
+	// Ensure emptyData implements the json.Marshaler interface
 	_ json.Marshaler = new(emptyData)
+	// Ensure emptyData implements the easyjson.Marshaler interface
+	_ easyjson.Marshaler = new(emptyData)
 )
 
 func (*emptyData) Value(key string) interface{} {
@@ -59,6 +75,14 @@ func (v *emptyData) MarshalJSON() ([]byte, error) {
 	return []byte("{}"), nil
 }
 
+func (v *emptyData) MarshalEasyJSON(w *jwriter.Writer) {
+	w.RawByte('{')
+	w.RawByte('}')
+}
+
+func (v *emptyData) MarshalJSONKeyValue(*jwriter.Writer, bool) {
+}
+
 // valueData represents a key, value pair in a metadata chain
 type valueData struct {
 	Metadata
@@ -69,8 +93,12 @@ type valueData struct {
 var (
 	// Ensure valueData implements the Metadata interface
 	_ Metadata = new(valueData)
+	// Ensure valueData implements the jsonMarshaler interface
+	_ jsonMarshaler = new(valueData)
 	// Ensure valueData implements the json.Marshaler interface
 	_ json.Marshaler = new(valueData)
+	// Ensure valueData implements the easyjson.Marshaler interface
+	_ easyjson.Marshaler = new(valueData)
 )
 
 func (v *valueData) Value(key string) interface{} {
@@ -95,7 +123,33 @@ func (v *valueData) AsMap() map[string]interface{} {
 }
 
 func (v *valueData) MarshalJSON() ([]byte, error) {
-	return json.Marshal(v.AsMap())
+	w := jwriter.Writer{}
+	v.MarshalEasyJSON(&w)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+func (v *valueData) MarshalEasyJSON(w *jwriter.Writer) {
+	w.RawByte('{')
+	v.MarshalJSONKeyValue(w, true)
+	w.RawByte('}')
+}
+
+func (v *valueData) MarshalJSONKeyValue(out *jwriter.Writer, last bool) {
+	marshalJSONKeyValues(out, v.Metadata)
+
+	out.String(v.key)
+	out.RawByte(':')
+	if vm, ok := v.val.(easyjson.Marshaler); ok {
+		vm.MarshalEasyJSON(out)
+	} else if vm, ok := v.val.(json.Marshaler); ok {
+		out.Raw(vm.MarshalJSON())
+	} else {
+		out.Raw(json.Marshal(v.val))
+	}
+
+	if !last {
+		out.RawByte(',')
+	}
 }
 
 // UnmarshalJSON unmarshals the provided json into a Metadata instance
@@ -126,4 +180,43 @@ func UnmarshalJSON(json []byte) (Metadata, error) {
 	}
 
 	return metadata, in.Error()
+}
+
+func marshalJSONKeyValues(out *jwriter.Writer, parent Metadata) {
+	if parent == nil {
+		return
+	}
+
+	if m, ok := parent.(jsonMarshaler); ok {
+		m.MarshalJSONKeyValue(out, false)
+		return
+	}
+
+	var (
+		parentJSON []byte
+		err        error
+	)
+	if vm, ok := parent.(easyjson.Marshaler); ok {
+		w := &jwriter.Writer{}
+		vm.MarshalEasyJSON(out)
+		parentJSON = w.Buffer.BuildBytes()
+		err = w.Error
+	} else if vm, ok := parent.(json.Marshaler); ok {
+		parentJSON, err = vm.MarshalJSON()
+	} else {
+		parentJSON, err = json.Marshal(parent)
+	}
+
+	if err != nil {
+		out.Raw(parentJSON, err)
+		return
+	}
+
+	plen := len(parentJSON)
+	if parentJSON[1] != '{' || parentJSON[plen-1] != '}' {
+		out.Raw(parentJSON, errors.Errorf("JSON unmarshal failed for Metadata of type %T", parent))
+		return
+	}
+
+	out.Raw(parentJSON[1:plen-2], nil)
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -4,8 +4,10 @@ package metadata_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/hellofresh/goengine/metadata"
 	"github.com/stretchr/testify/assert"
@@ -201,11 +203,18 @@ var jsonTestCases = []struct {
 func TestMarshalJSON(t *testing.T) {
 	for _, testCase := range jsonTestCases {
 		t.Run(testCase.title, func(t *testing.T) {
+			expectedJSON := strings.Map(func(r rune) rune {
+				if unicode.IsSpace(r) {
+					return -1
+				}
+				return r
+			}, testCase.json)
+
 			m := testCase.metadata()
 
 			mJSON, err := json.Marshal(m)
 
-			assert.JSONEq(t, testCase.json, string(mJSON))
+			assert.Equal(t, expectedJSON, string(mJSON))
 			assert.NoError(t, err)
 		})
 	}
@@ -218,7 +227,7 @@ func TestUnmarshalJSON(t *testing.T) {
 
 			// Need to use AsMap otherwise we can have inconsistent tests results.
 			if assert.NoError(t, err) {
-				assert.Equal(t, testCase.metadata().AsMap(), m.AsMap())
+				assert.Equal(t, testCase.metadata(), m)
 			}
 		})
 	}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -198,7 +198,7 @@ var jsonTestCases = []struct {
 	},
 }
 
-func TestMetadata_MarshalJSON(t *testing.T) {
+func TestMarshalJSON(t *testing.T) {
 	for _, testCase := range jsonTestCases {
 		t.Run(testCase.title, func(t *testing.T) {
 			m := testCase.metadata()
@@ -211,7 +211,7 @@ func TestMetadata_MarshalJSON(t *testing.T) {
 	}
 }
 
-func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
+func TestUnmarshalJSON(t *testing.T) {
 	for _, testCase := range jsonTestCases {
 		t.Run(testCase.title, func(t *testing.T) {
 			m, err := metadata.UnmarshalJSON([]byte(testCase.json))
@@ -224,12 +224,27 @@ func TestJSONMetadata_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-func BenchmarkJSONMetadata_UnmarshalJSON(b *testing.B) {
+func BenchmarkUnmarshalJSON(b *testing.B) {
 	payload := []byte(`{"_aggregate_id": "b9ebca7a-c1eb-40dd-94a4-fac7c5e84fb5", "_aggregate_type": "bank_account", "_aggregate_version": 1}`)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := metadata.UnmarshalJSON(payload)
+		if err != nil {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkMarshalJSON(b *testing.B) {
+	m := metadata.New()
+	m = metadata.WithValue(m, "_aggregate_id", "b9ebca7a-c1eb-40dd-94a4-fac7c5e84fb5")
+	m = metadata.WithValue(m, "_aggregate_type", "bank_account")
+	m = metadata.WithValue(m, "_aggregate_version", 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := json.Marshal(m)
 		if err != nil {
 			b.Fail()
 		}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/hellofresh/goengine/metadata"
+	"github.com/mailru/easyjson"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -253,7 +254,7 @@ func BenchmarkMarshalJSON(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := json.Marshal(m)
+		_, err := easyjson.Marshal(m.(easyjson.Marshaler))
 		if err != nil {
 			b.Fail()
 		}

--- a/strategy/json/internal/json.go
+++ b/strategy/json/internal/json.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"encoding/json"
+
+	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
+)
+
+// MarshalJSON returns the JSON encoding of v.
+// This is done using `easyjson.Marshaler`, `json.Marshaler` or `json.Marshal`
+func MarshalJSON(v interface{}) ([]byte, error) {
+	if vm, ok := v.(easyjson.Marshaler); ok {
+		w := &jwriter.Writer{}
+		vm.MarshalEasyJSON(w)
+		return w.Buffer.BuildBytes(), w.Error
+	}
+
+	if vm, ok := v.(json.Marshaler); ok {
+		return vm.MarshalJSON()
+	}
+
+	return json.Marshal(v)
+}

--- a/strategy/json/internal/json.go
+++ b/strategy/json/internal/json.go
@@ -22,3 +22,18 @@ func MarshalJSON(v interface{}) ([]byte, error) {
 
 	return json.Marshal(v)
 }
+
+// UnmarshalJSON parses the JSON-encoded data and stores the result
+// in the value pointed to by v.
+// This is done using `easyjson.Unmarshal`, `json.Unmarshaler` or `json.Unmarshal`
+func UnmarshalJSON(data []byte, v interface{}) error {
+	if vm, ok := v.(easyjson.Unmarshaler); ok {
+		return easyjson.Unmarshal(data, vm)
+	}
+
+	if vm, ok := v.(json.Unmarshaler); ok {
+		return vm.UnmarshalJSON(data)
+	}
+
+	return json.Unmarshal(data, v)
+}

--- a/strategy/json/payload_transformer.go
+++ b/strategy/json/payload_transformer.go
@@ -146,7 +146,7 @@ func (p *PayloadTransformer) CreatePayload(typeName string, data interface{}) (i
 
 	// Pointer we can handle nicely
 	if payloadType.isPtr {
-		if err := json.Unmarshal(dataBytes, payload); err != nil {
+		if err := internal.UnmarshalJSON(dataBytes, payload); err != nil {
 			return nil, err
 		}
 	}
@@ -154,7 +154,7 @@ func (p *PayloadTransformer) CreatePayload(typeName string, data interface{}) (i
 	// Not a pointer so let's cry and use reflection
 	vp := reflect.New(payloadType.reflectionType)
 	vp.Elem().Set(reflect.ValueOf(payload))
-	if err := json.Unmarshal(dataBytes, vp.Interface()); err != nil {
+	if err := internal.UnmarshalJSON(dataBytes, vp.Interface()); err != nil {
 		return nil, err
 	}
 

--- a/strategy/json/payload_transformer.go
+++ b/strategy/json/payload_transformer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hellofresh/goengine"
 	reflectUtil "github.com/hellofresh/goengine/internal/reflect"
+	"github.com/hellofresh/goengine/strategy/json/internal"
 )
 
 var (
@@ -66,7 +67,7 @@ func (p *PayloadTransformer) ConvertPayload(payload interface{}) (string, []byte
 		return "", nil, err
 	}
 
-	data, err := json.Marshal(payload)
+	data, err := internal.MarshalJSON(payload)
 	if err != nil {
 		return "", nil, ErrPayloadCannotBeSerialized
 	}

--- a/strategy/json/sql/message_factory_aggregate_test.go
+++ b/strategy/json/sql/message_factory_aggregate_test.go
@@ -3,18 +3,17 @@
 package sql_test
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/golang/mock/gomock"
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/aggregate"
 	"github.com/hellofresh/goengine/metadata"
 	"github.com/hellofresh/goengine/mocks"
+	"github.com/hellofresh/goengine/strategy/json/internal"
 	"github.com/hellofresh/goengine/strategy/json/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,10 +69,10 @@ func TestAggregateChangedFactory_CreateFromRows(t *testing.T) {
 				payloadFactory := mocks.NewMessagePayloadFactory(ctrl)
 				mockRows := sqlmock.NewRows(rowColumns)
 				for i, msg := range expectedMessages {
-					rowPayload, err := json.Marshal(msg.Payload())
+					rowPayload, err := internal.MarshalJSON(msg.Payload())
 					require.NoError(t, err)
 
-					rowMetadata, err := json.Marshal(msg.Metadata())
+					rowMetadata, err := internal.MarshalJSON(msg.Metadata())
 					require.NoError(t, err)
 
 					msgNr := i + 1

--- a/strategy/json/sql/postgres/single_stream_strategy.go
+++ b/strategy/json/sql/postgres/single_stream_strategy.go
@@ -1,15 +1,14 @@
 package postgres
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 
-	"github.com/hellofresh/goengine/driver/sql/postgres"
-
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/driver/sql"
+	"github.com/hellofresh/goengine/driver/sql/postgres"
+	"github.com/hellofresh/goengine/strategy/json/internal"
 )
 
 var (
@@ -81,7 +80,7 @@ func (s *SingleStreamStrategy) PrepareData(messages []goengine.Message) ([]inter
 			return nil, err
 		}
 
-		meta, err := json.Marshal(msg.Metadata())
+		meta, err := internal.MarshalJSON(msg.Metadata())
 		if err != nil {
 			return nil, err
 		}

--- a/strategy/json/sql/postgres/single_stream_strategy_test.go
+++ b/strategy/json/sql/postgres/single_stream_strategy_test.go
@@ -3,7 +3,6 @@
 package postgres_test
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/metadata"
 	"github.com/hellofresh/goengine/mocks"
+	"github.com/hellofresh/goengine/strategy/json/internal"
 	"github.com/hellofresh/goengine/strategy/json/sql/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,7 +181,7 @@ func TestPrepareData(t *testing.T) {
 
 			pc.EXPECT().ConvertPayload(payload).Return(payloadType, payload, nil).AnyTimes()
 
-			metaJSON, err := json.Marshal(meta)
+			metaJSON, err := internal.MarshalJSON(meta)
 			require.NoError(t, err)
 
 			expectedColumns = append(


### PR DESCRIPTION
Currently GoEngine uses easyjson for json unmarshalling of metadata. 
This PR adds support for easyjson for each type that can support it.