### PR TITLE
Remove useless []*Changed

### DIFF
--- a/aggregate/aggregate.go
+++ b/aggregate/aggregate.go
@@ -39,7 +39,7 @@ type (
 	}
 
 	eventSourced interface {
-		replay(aggregate EventApplier, historyEvents []*Changed)
+		replay(aggregate EventApplier, historyEvents goengine.EventStream) error
 		recordThat(aggregate EventApplier, event *Changed)
 	}
 )


### PR DESCRIPTION
While doing some memory benchmarking I noticed that the `GetAggregate` was eating some memory. 
In order to improve this I moved make the BaseRoot replay accept a `EventStream` by doing this the extra slice that was needed can now be removed.