### PR TITLE
Update logger interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -117,7 +117,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:c52caf7bd44f92e54627a31b85baf06a68333a196b3d8d241480a774733dcf8b"
+  digest = "1:adccce69c151272d5053505aee552c6a1ac4e7bf6d18f0206ed7453187f6284d"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -126,6 +126,7 @@
     "internal/color",
     "internal/exit",
     "zapcore",
+    "zaptest/observer",
   ]
   pruneopts = "UT"
   revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
@@ -161,6 +162,7 @@
     "github.com/lib/pq",
     "github.com/mailru/easyjson",
     "github.com/mailru/easyjson/jlexer",
+    "github.com/mailru/easyjson/jwriter",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/sirupsen/logrus/hooks/test",
@@ -168,6 +170,7 @@
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
     "go.uber.org/zap",
+    "go.uber.org/zap/zaptest/observer",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/driver/inmemory/matcher.go
+++ b/driver/inmemory/matcher.go
@@ -84,10 +84,10 @@ func (m *MetadataMatcher) Matches(metadata metadata.Metadata) bool {
 		valid, err := c.Matches(metadata.Value(c.field))
 		if err != nil {
 			if m.logger != nil {
-				m.logger.
-					WithError(err).
-					WithField("field", c.field).
-					Warn("metadata constraint failed with error")
+				m.logger.Warn("metadata constraint failed with error", func(e goengine.LoggerEntry) {
+					e.Error(err)
+					e.String("field", c.field)
+				})
 			}
 			return false
 		}

--- a/driver/sql/internal/background_processor.go
+++ b/driver/sql/internal/background_processor.go
@@ -124,10 +124,10 @@ func (b *BackgroundProcessor) startProcessor(ctx context.Context, handler Proces
 		case notification := <-b.queue:
 			// Execute the notification
 			if err := handler(ctx, notification, b.Queue); err != nil {
-				b.logger.
-					WithError(err).
-					WithField("notification", notification).
-					Error("the ProcessHandler produced an error")
+				b.logger.Error("the ProcessHandler produced an error", func(e goengine.LoggerEntry) {
+					e.Error(err)
+					e.Any("notification", notification)
+				})
 			}
 		}
 	}

--- a/driver/sql/postgres/conjoined_eventstore.go
+++ b/driver/sql/postgres/conjoined_eventstore.go
@@ -42,9 +42,9 @@ func (e *ConjoinedEventStore) AppendTo(ctx context.Context, streamName goengine.
 	}
 	defer func() {
 		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
-			e.logger.
-				WithError(err).
-				Error("could not rollback transaction")
+			e.logger.Error("could not rollback transaction", func(e goengine.LoggerEntry) {
+				e.Error(err)
+			})
 		}
 	}()
 
@@ -58,9 +58,10 @@ func (e *ConjoinedEventStore) AppendTo(ctx context.Context, streamName goengine.
 		// Resolve the payload event name
 		eventName, err := e.resolver.ResolveName(msg.Payload())
 		if err != nil {
-			e.logger.
-				WithField("payload", msg.Payload()).
-				Warn("skipping event: unable to resolve payload name")
+			e.logger.Warn("skipping event: unable to resolve payload name", func(e goengine.LoggerEntry) {
+				e.Error(err)
+				e.Any("payload", msg.Payload())
+			})
 			continue
 		}
 

--- a/driver/sql/postgres/eventstore.go
+++ b/driver/sql/postgres/eventstore.go
@@ -97,10 +97,10 @@ func (e *EventStore) Create(ctx context.Context, streamName goengine.StreamName)
 		}
 
 		if errRollback := tx.Rollback(); errRollback != nil {
-			e.logger.
-				WithError(errRollback).
-				WithField("query", q).
-				Error("could not rollback transaction")
+			e.logger.Error("could not rollback transaction", func(e goengine.LoggerEntry) {
+				e.Error(errRollback)
+				e.String("query", q)
+			})
 		}
 
 		return err
@@ -217,24 +217,21 @@ func (e *EventStore) AppendToWithExecer(ctx context.Context, conn driverSQL.Exec
 		data...,
 	)
 	if err != nil {
-		e.logger.
-			WithError(err).
-			WithFields(goengine.Fields{
-				"streamName":   streamName,
-				"streamEvents": streamEvents,
-			}).
-			Warn("failed to insert messages into the event stream")
+		e.logger.Warn("failed to insert messages into the event stream", func(e goengine.LoggerEntry) {
+			e.Error(err)
+			e.String("streamName", string(streamName))
+			e.Any("streamEvents", streamEvents)
+		})
 
 		return err
 	}
 
-	e.logger.
-		WithFields(goengine.Fields{
-			"streamName":   streamName,
-			"streamEvents": streamEvents,
-			"result":       result,
-		}).
-		Debug("inserted messages into the event stream")
+	e.logger.Debug("inserted messages into the event stream", func(e goengine.LoggerEntry) {
+		e.Error(err)
+		e.String("streamName", string(streamName))
+		e.Any("streamEvents", streamEvents)
+		e.Any("result", result)
+	})
 
 	return nil
 }
@@ -306,10 +303,10 @@ func (e *EventStore) tableExists(ctx context.Context, tableName string) bool {
 	).Scan(&exists)
 
 	if err != nil {
-		e.logger.
-			WithError(err).
-			WithField("table", tableName).
-			Warn("error on reading from information_schema")
+		e.logger.Warn("error on reading from information_schema", func(e goengine.LoggerEntry) {
+			e.Error(err)
+			e.String("table", tableName)
+		})
 
 		return false
 	}

--- a/driver/sql/postgres/projector_aggregate.go
+++ b/driver/sql/postgres/projector_aggregate.go
@@ -162,7 +162,8 @@ func (a *AggregateProjector) processNotification(
 	// Resolve the action to take based on the error that occurred
 	logFields := func(e goengine.LoggerEntry) {
 		e.Error(err)
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 	}
 	switch resolveErrorAction(a.projectionErrorHandler, notification, err) {
 	case errorFail:
@@ -231,13 +232,15 @@ func (a *AggregateProjector) triggerOutOfSyncProjections(ctx context.Context, qu
 		if err := queue(ctx, notification); err != nil {
 			a.logger.Error("failed to queue notification", func(e goengine.LoggerEntry) {
 				e.Error(err)
-				e.Any("notification", notification)
+				e.Int64("notification.no", notification.No)
+				e.String("notification.aggregate_id", notification.AggregateID)
 			})
 			return err
 		}
 
 		a.logger.Debug("send catchup", func(e goengine.LoggerEntry) {
-			e.Any("notification", notification)
+			e.Int64("notification.no", notification.No)
+			e.String("notification.aggregate_id", notification.AggregateID)
 		})
 	}
 

--- a/driver/sql/postgres/projector_aggregate_storage.go
+++ b/driver/sql/postgres/projector_aggregate_storage.go
@@ -129,10 +129,10 @@ func (a *aggregateProjectionStorage) PersistState(conn driverSQL.Execer, notific
 		return err
 	}
 
-	a.logger.WithFields(goengine.Fields{
-		"notification": notification,
-		"state":        state,
-	}).Debug("updated projection state")
+	a.logger.Debug("updated projection state", func(e goengine.LoggerEntry) {
+		e.Any("notification", notification)
+		e.Any("state", state)
+	})
 	return nil
 }
 
@@ -149,7 +149,9 @@ func (a *aggregateProjectionStorage) Acquire(
 	conn *sql.Conn,
 	notification *driverSQL.ProjectionNotification,
 ) (func(), *driverSQL.ProjectionRawState, error) {
-	logger := a.logger.WithField("notification", notification)
+	logFields := func(e goengine.LoggerEntry) {
+		e.Any("notification", notification)
+	}
 	aggregateID := notification.AggregateID
 
 	res := conn.QueryRowContext(ctx, a.queryAcquireLock, aggregateID, notification.No)
@@ -178,9 +180,12 @@ func (a *aggregateProjectionStorage) Acquire(
 		// The projection was locked by another process that died and for this reason not unlocked
 		// In this case a application needs to decide what to do to avoid invalid projection states
 		if err := a.releaseProjectionConnectionLock(conn, aggregateID); err != nil {
-			logger.WithError(err).Error("failed to release lock for a projection with a locked row")
+			a.logger.Error("failed to release lock for a projection with a locked row", func(e goengine.LoggerEntry) {
+				logFields(e)
+				e.Error(err)
+			})
 		} else {
-			logger.Debug("released connection lock for a locked projection")
+			a.logger.Debug("released connection lock for a locked projection", logFields)
 		}
 
 		return nil, nil, driverSQL.ErrProjectionPreviouslyLocked
@@ -190,20 +195,26 @@ func (a *aggregateProjectionStorage) Acquire(
 	_, err := conn.ExecContext(ctx, a.querySetRowLocked, aggregateID, true)
 	if err != nil {
 		if releaseErr := a.releaseProjection(conn, aggregateID); releaseErr != nil {
-			logger.WithError(releaseErr).Error("failed to release lock while setting projection rows as locked")
+			a.logger.Error("failed to release lock while setting projection rows as locked", func(e goengine.LoggerEntry) {
+				logFields(e)
+				e.Error(releaseErr)
+			})
 		} else {
-			logger.Debug("failed to set projection as locked")
+			a.logger.Debug("failed to set projection as locked", logFields)
 		}
 
 		return nil, nil, err
 	}
-	logger.Debug("acquired projection lock")
+	a.logger.Debug("acquired projection lock", logFields)
 
 	return func() {
 		if err := a.releaseProjection(conn, aggregateID); err != nil {
-			logger.WithError(err).Error("failed to release projection lock")
+			a.logger.Error("failed to release projection lock", func(e goengine.LoggerEntry) {
+				logFields(e)
+				e.Error(err)
+			})
 		} else {
-			logger.Debug("released projection lock")
+			a.logger.Debug("released projection lock", logFields)
 		}
 	}, &driverSQL.ProjectionRawState{ProjectionState: rawState, Position: position}, nil
 }

--- a/driver/sql/postgres/projector_aggregate_storage.go
+++ b/driver/sql/postgres/projector_aggregate_storage.go
@@ -130,7 +130,8 @@ func (a *aggregateProjectionStorage) PersistState(conn driverSQL.Execer, notific
 	}
 
 	a.logger.Debug("updated projection state", func(e goengine.LoggerEntry) {
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 		e.Any("state", state)
 	})
 	return nil
@@ -150,7 +151,8 @@ func (a *aggregateProjectionStorage) Acquire(
 	notification *driverSQL.ProjectionNotification,
 ) (func(), *driverSQL.ProjectionRawState, error) {
 	logFields := func(e goengine.LoggerEntry) {
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 	}
 	aggregateID := notification.AggregateID
 

--- a/driver/sql/postgres/projector_stream.go
+++ b/driver/sql/postgres/projector_stream.go
@@ -54,7 +54,9 @@ func NewStreamProjector(
 	if logger == nil {
 		logger = goengine.NopLogger
 	}
-	logger = logger.WithField("projection", projection)
+	logger = logger.WithFields(func(e goengine.LoggerEntry) {
+		e.String("projection", projection.Name())
+	})
 
 	var (
 		stateDecoder driverSQL.ProjectionStateDecoder
@@ -144,16 +146,19 @@ func (s *StreamProjector) processNotification(
 		}
 
 		// Resolve the action to take based on the error that occurred
-		logger := s.logger.WithError(err).WithField("notification", notification)
+		logFields := func(e goengine.LoggerEntry) {
+			e.Error(err)
+			e.Any("notification", notification)
+		}
 		switch resolveErrorAction(s.projectionErrorHandler, notification, err) {
 		case errorRetry:
-			logger.Debug("Trigger->ErrorHandler: retrying notification")
+			s.logger.Debug("Trigger->ErrorHandler: retrying notification", logFields)
 			continue
 		case errorIgnore:
-			logger.Debug("Trigger->ErrorHandler: ignoring error")
+			s.logger.Debug("Trigger->ErrorHandler: ignoring error", logFields)
 			return nil
 		case errorFail, errorFallthrough:
-			logger.Debug("Trigger->ErrorHandler: error fallthrough")
+			s.logger.Debug("Trigger->ErrorHandler: error fallthrough", logFields)
 			return err
 		}
 	}

--- a/driver/sql/postgres/projector_stream.go
+++ b/driver/sql/postgres/projector_stream.go
@@ -148,7 +148,8 @@ func (s *StreamProjector) processNotification(
 		// Resolve the action to take based on the error that occurred
 		logFields := func(e goengine.LoggerEntry) {
 			e.Error(err)
-			e.Any("notification", notification)
+			e.Int64("notification.no", notification.No)
+			e.String("notification.aggregate_id", notification.AggregateID)
 		}
 		switch resolveErrorAction(s.projectionErrorHandler, notification, err) {
 		case errorRetry:

--- a/driver/sql/postgres/projector_stream_storage.go
+++ b/driver/sql/postgres/projector_stream_storage.go
@@ -108,7 +108,8 @@ func (s *streamProjectionStorage) PersistState(conn driverSQL.Execer, notificati
 		return err
 	}
 	s.logger.Debug("updated projection state", func(e goengine.LoggerEntry) {
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 		e.Any("state", state)
 	})
 
@@ -121,7 +122,8 @@ func (s *streamProjectionStorage) Acquire(
 	notification *driverSQL.ProjectionNotification,
 ) (func(), *driverSQL.ProjectionRawState, error) {
 	logFields := func(e goengine.LoggerEntry) {
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 	}
 
 	var res *sql.Row

--- a/extension/logrus/logrus.go
+++ b/extension/logrus/logrus.go
@@ -1,6 +1,8 @@
 package logrus
 
 import (
+	"sync/atomic"
+
 	"github.com/hellofresh/goengine"
 	"github.com/sirupsen/logrus"
 )
@@ -11,51 +13,96 @@ type wrapper struct {
 
 // Wrap wraps a logrus.Logger
 func Wrap(logger *logrus.Logger) goengine.Logger {
-	return wrapper{entry: logrus.NewEntry(logger)}
+	return &wrapper{entry: logrus.NewEntry(logger)}
 }
 
 // WrapEntry wraps a logrus.Entry
 func WrapEntry(entry *logrus.Entry) goengine.Logger {
-	return wrapper{entry: entry}
+	return &wrapper{entry: entry}
 }
 
 // StandardLogger return a wrapped version of the logrus.StandardLogger()
 func StandardLogger() goengine.Logger {
 	var origLogger = logrus.StandardLogger()
-	return wrapper{entry: logrus.NewEntry(origLogger)}
+	return &wrapper{entry: logrus.NewEntry(origLogger)}
 }
 
-// Error writes a log with log level error
-func (w wrapper) Error(msg string) {
-	w.entry.Error(msg)
+func (w wrapper) Error(msg string, fields func(goengine.LoggerEntry)) {
+	if fields == nil {
+		w.entry.Error(msg)
+		return
+	}
+
+	if w.enabled(logrus.ErrorLevel) {
+		w.entry.WithFields(fieldsToMap(fields)).Error(msg)
+	}
 }
 
-// Warn writes a log with log level warn
-func (w wrapper) Warn(msg string) {
-	w.entry.Warn(msg)
+func (w wrapper) Warn(msg string, fields func(goengine.LoggerEntry)) {
+	if fields == nil {
+		w.entry.Warn(msg)
+		return
+	}
+
+	if w.enabled(logrus.WarnLevel) {
+		w.entry.WithFields(fieldsToMap(fields)).Warn(msg)
+	}
 }
 
-// Info writes a log with log level info
-func (w wrapper) Info(msg string) {
-	w.entry.Warn(msg)
+func (w wrapper) Info(msg string, fields func(goengine.LoggerEntry)) {
+	if fields == nil {
+		w.entry.Info(msg)
+		return
+	}
+
+	if w.enabled(logrus.InfoLevel) {
+		w.entry.WithFields(fieldsToMap(fields)).Info(msg)
+	}
 }
 
-// Debug writes a log with log level debug
-func (w wrapper) Debug(msg string) {
-	w.entry.Debug(msg)
+func (w wrapper) Debug(msg string, fields func(goengine.LoggerEntry)) {
+	if fields == nil {
+		w.entry.Debug(msg)
+		return
+	}
+
+	if w.enabled(logrus.DebugLevel) {
+		w.entry.WithFields(fieldsToMap(fields)).Debug(msg)
+	}
 }
 
-// WithError Add an error as single field to the log entry
-func (w wrapper) WithError(err error) goengine.Logger {
-	return wrapper{entry: w.entry.WithError(err)}
+func (w *wrapper) WithFields(fields func(goengine.LoggerEntry)) goengine.Logger {
+	if fields == nil {
+		return w
+	}
+
+	return &wrapper{entry: w.entry.WithFields(fieldsToMap(fields))}
 }
 
-// WithField Adds a field to the log entry
-func (w wrapper) WithField(key string, val interface{}) goengine.Logger {
-	return wrapper{entry: w.entry.WithField(key, val)}
+func (w wrapper) enabled(level logrus.Level) bool {
+	return logrus.Level(atomic.LoadUint32((*uint32)(&w.entry.Logger.Level))) >= level
 }
 
-//WithFields Adds a set of fields to the log entry
-func (w wrapper) WithFields(fields goengine.Fields) goengine.Logger {
-	return wrapper{entry: w.entry.WithFields(logrus.Fields(fields))}
+func fieldsToMap(fields func(goengine.LoggerEntry)) logrus.Fields {
+	e := entry{}
+	fields(e)
+	return logrus.Fields(e)
+}
+
+type entry map[string]interface{}
+
+func (e entry) Int(k string, v int) {
+	e[k] = v
+}
+
+func (e entry) String(k, v string) {
+	e[k] = v
+}
+
+func (e entry) Error(err error) {
+	e["error"] = err
+}
+
+func (e entry) Any(k string, v interface{}) {
+	e[k] = v
 }

--- a/extension/logrus/logrus.go
+++ b/extension/logrus/logrus.go
@@ -95,6 +95,10 @@ func (e entry) Int(k string, v int) {
 	e[k] = v
 }
 
+func (e entry) Int64(k string, v int64) {
+	e[k] = v
+}
+
 func (e entry) String(k, v string) {
 	e[k] = v
 }

--- a/extension/logrus/logrus_test.go
+++ b/extension/logrus/logrus_test.go
@@ -5,6 +5,8 @@ package logrus_test
 import (
 	"testing"
 
+	"github.com/hellofresh/goengine"
+
 	"github.com/hellofresh/goengine/extension/logrus"
 )
 
@@ -15,6 +17,8 @@ func BenchmarkStandardLoggerEntry(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		logger.WithField("i", n).Debug("test")
+		logger.Debug("test", func(e goengine.LoggerEntry) {
+			e.Int("i", n)
+		})
 	}
 }

--- a/extension/logrus/logrus_test.go
+++ b/extension/logrus/logrus_test.go
@@ -3,17 +3,140 @@
 package logrus_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/hellofresh/goengine"
-
-	"github.com/hellofresh/goengine/extension/logrus"
+	logrusExtension "github.com/hellofresh/goengine/extension/logrus"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestWrap_LogEntry(t *testing.T) {
+	logrusLogger, logObserver := test.NewNullLogger()
+	logrusLogger.SetLevel(logrus.DebugLevel)
+	logger := logrusExtension.Wrap(logrusLogger)
+
+	testCases := []struct {
+		msg    string
+		fields func(goengine.LoggerEntry)
+
+		expectedMsg     string
+		expectedContext logrus.Fields
+	}{
+		{
+			"test nil fields",
+			nil,
+			"test nil fields",
+			logrus.Fields{},
+		},
+		{
+			"test with fields",
+			func(e goengine.LoggerEntry) {
+				e.String("test", "a value")
+				e.Int("normal_int", 99)
+				e.Int64("int_64", 2)
+				e.Error(errors.New("some error"))
+				e.Any("obj", struct {
+					test string
+				}{test: "test property"})
+			},
+			"test with fields",
+			logrus.Fields{
+				"test":       "a value",
+				"normal_int": 99,
+				"int_64":     int64(2),
+				"error":      errors.New("some error"),
+				"obj": struct {
+					test string
+				}{test: "test property"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.msg, func(t *testing.T) {
+			defer logObserver.Reset()
+
+			logger.Error(testCase.msg, testCase.fields)
+			logger.Warn(testCase.msg, testCase.fields)
+			logger.Info(testCase.msg, testCase.fields)
+			logger.Debug(testCase.msg, testCase.fields)
+
+			logs := logObserver.AllEntries()
+			if !assert.Len(t, logs, 4) {
+				return
+			}
+
+			levelOrder := []logrus.Level{
+				logrus.ErrorLevel,
+				logrus.WarnLevel,
+				logrus.InfoLevel,
+				logrus.DebugLevel,
+			}
+
+			for i, level := range levelOrder {
+				assert.Equal(t, level, logs[i].Level)
+				assert.Equal(t, testCase.expectedMsg, logs[i].Message)
+				assert.Equal(t, testCase.expectedContext, logs[i].Data)
+			}
+		})
+	}
+
+	t.Run("Do not log disabled levels", func(t *testing.T) {
+		logrusLogger.SetLevel(logrus.InfoLevel)
+
+		logger.Debug("should not be logged", func(e goengine.LoggerEntry) {
+			t.Error("fields should not be called")
+		})
+
+		assert.Len(t, logObserver.AllEntries(), 0)
+	})
+}
+
+func TestWrapper_WithFields(t *testing.T) {
+	logrusLogger, logObserver := test.NewNullLogger()
+	logrusLogger.SetLevel(logrus.DebugLevel)
+	logger := logrusExtension.Wrap(logrusLogger)
+
+	t.Run("With fields", func(t *testing.T) {
+		loggerWithFields := logger.WithFields(func(e goengine.LoggerEntry) {
+			e.String("with field", "check")
+			e.String("val", "default")
+		})
+
+		loggerWithFields.Debug("test with nil", nil)
+		loggerWithFields.Debug("test with override", func(e goengine.LoggerEntry) {
+			e.String("val", "override")
+		})
+
+		logs := logObserver.AllEntries()
+		if assert.Len(t, logs, 2) {
+			assert.Equal(t, "test with nil", logs[0].Message)
+			assert.Equal(t, logrus.Fields{
+				"with field": "check",
+				"val":        "default",
+			}, logs[0].Data)
+
+			assert.Equal(t, "test with override", logs[1].Message)
+			assert.Equal(t, logrus.Fields{
+				"with field": "check",
+				"val":        "override",
+			}, logs[1].Data)
+		}
+	})
+
+	t.Run("With fields nil", func(t *testing.T) {
+		loggerWithFields := logger.WithFields(nil)
+		assert.Equal(t, logger, loggerWithFields)
+	})
+}
 
 func BenchmarkStandardLoggerEntry(b *testing.B) {
 	b.ReportAllocs()
 
-	logger := logrus.StandardLogger()
+	logger := logrusExtension.StandardLogger()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/extension/pq/listener.go
+++ b/extension/pq/listener.go
@@ -70,7 +70,9 @@ func (s *Listener) Listen(ctx context.Context, exec sql.ProjectionTrigger) error
 	listener := pq.NewListener(s.dbDSN, s.minReconnectInterval, s.maxReconnectInterval, s.listenerStateCallback)
 	defer func() {
 		if err := listener.Close(); err != nil {
-			s.logger.WithError(err).Warn("failed to close database Listener")
+			s.logger.Warn("failed to close database Listener", func(e goengine.LoggerEntry) {
+				e.Error(err)
+			})
 		}
 	}()
 
@@ -96,7 +98,7 @@ func (s *Listener) Listen(ctx context.Context, exec sql.ProjectionTrigger) error
 				return err
 			}
 		case <-ctx.Done():
-			s.logger.Debug("context closed stopping projection")
+			s.logger.Debug("context closed stopping projection", nil)
 			return nil
 		}
 	}
@@ -105,45 +107,54 @@ func (s *Listener) Listen(ctx context.Context, exec sql.ProjectionTrigger) error
 // listenerStateCallback a callback used for getting state changes from a pq.Listener
 // This callback will also close the related db connection pool used to query/persist projection data
 func (s *Listener) listenerStateCallback(event pq.ListenerEventType, err error) {
-	logger := s.logger.WithField("listener_event", event)
-	if err != nil {
-		logger = logger.WithError(err)
+	logFields := func(e goengine.LoggerEntry) {
+		e.Int("listener_event", int(event))
+		if err != nil {
+			e.Error(err)
+		}
 	}
 
 	switch event {
 	case pq.ListenerEventConnected:
-		logger.Debug("connection Listener: connected")
+		s.logger.Debug("connection Listener: connected", logFields)
 	case pq.ListenerEventConnectionAttemptFailed:
-		logger.Debug("connection Listener: failed to connect")
+		s.logger.Debug("connection Listener: failed to connect", logFields)
 	case pq.ListenerEventDisconnected:
-		logger.Debug("connection Listener: disconnected")
+		s.logger.Debug("connection Listener: disconnected", logFields)
 	case pq.ListenerEventReconnected:
-		logger.Debug("connection Listener: reconnected")
+		s.logger.Debug("connection Listener: reconnected", logFields)
 	default:
-		logger.Warn("connection Listener: unknown event")
+		s.logger.Warn("connection Listener: unknown event", logFields)
 	}
 }
 
 // unmarshalNotification takes a postgres notification and unmarshal it into a eventStoreNotification
 func (s *Listener) unmarshalNotification(n *pq.Notification) *sql.ProjectionNotification {
 	if n == nil {
-		s.logger.Info("received nil notification")
+		s.logger.Info("received nil notification", nil)
 		return nil
 	}
 
-	logger := s.logger.WithField("pq_notification", n)
 	if n.Extra == "" {
-		logger.Error("received notification without extra data")
+		s.logger.Error("received notification without extra data", func(e goengine.LoggerEntry) {
+			e.Any("pq_notification", n)
+		})
 		return nil
 	}
 
 	notification := &sql.ProjectionNotification{}
 	if err := easyjson.Unmarshal([]byte(n.Extra), notification); err != nil {
-		logger.WithError(err).Error("received invalid notification data")
+		s.logger.Error("received invalid notification data", func(e goengine.LoggerEntry) {
+			e.Any("pq_notification", n)
+			e.Error(err)
+		})
 		return nil
 	}
 
-	logger.WithField("notification", notification).Debug("received notification")
+	s.logger.Debug("received notification", func(e goengine.LoggerEntry) {
+		e.Any("pq_notification", n)
+		e.Any("notification", notification)
+	})
 
 	return notification
 }

--- a/extension/pq/listener.go
+++ b/extension/pq/listener.go
@@ -153,7 +153,8 @@ func (s *Listener) unmarshalNotification(n *pq.Notification) *sql.ProjectionNoti
 
 	s.logger.Debug("received notification", func(e goengine.LoggerEntry) {
 		e.Any("pq_notification", n)
-		e.Any("notification", notification)
+		e.Int64("notification.no", notification.No)
+		e.String("notification.aggregate_id", notification.AggregateID)
 	})
 
 	return notification

--- a/extension/zap/zap.go
+++ b/extension/zap/zap.go
@@ -65,6 +65,10 @@ func (e *entry) Int(k string, v int) {
 	e.fields = append(e.fields, zap.Int(k, v))
 }
 
+func (e *entry) Int64(k string, v int64) {
+	e.fields = append(e.fields, zap.Int64(k, v))
+}
+
 func (e *entry) String(k, v string) {
 	e.fields = append(e.fields, zap.String(k, v))
 }

--- a/extension/zap/zap_test.go
+++ b/extension/zap/zap_test.go
@@ -5,6 +5,8 @@ package zap_test
 import (
 	"testing"
 
+	"github.com/hellofresh/goengine"
+
 	zapExtension "github.com/hellofresh/goengine/extension/zap"
 	"go.uber.org/zap"
 )
@@ -17,6 +19,8 @@ func BenchmarkStandardLoggerEntry(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		logger.WithField("i", n).Debug("test")
+		logger.Debug("test", func(e goengine.LoggerEntry) {
+			e.Int("i", n)
+		})
 	}
 }

--- a/extension/zap/zap_test.go
+++ b/extension/zap/zap_test.go
@@ -3,13 +3,134 @@
 package zap_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/hellofresh/goengine"
-
 	zapExtension "github.com/hellofresh/goengine/extension/zap"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestWrap_LogEntry(t *testing.T) {
+	zapCore, logObserver := observer.New(zapcore.DebugLevel)
+	logger := zapExtension.Wrap(zap.New(zapCore))
+
+	testCases := []struct {
+		msg    string
+		fields func(goengine.LoggerEntry)
+
+		expectedMsg     string
+		expectedContext map[string]interface{}
+	}{
+		{
+			"test nil fields",
+			nil,
+			"test nil fields",
+			map[string]interface{}{},
+		},
+		{
+			"test with fields",
+			func(e goengine.LoggerEntry) {
+				e.String("test", "a value")
+				e.Int("normal_int", 99)
+				e.Int64("int_64", 2)
+				e.Error(errors.New("some error"))
+				e.Any("obj", struct {
+					test string
+				}{test: "test property"})
+			},
+			"test with fields",
+			map[string]interface{}{
+				"test":       "a value",
+				"normal_int": int64(99),
+				"int_64":     int64(2),
+				"error":      "some error",
+				"obj": struct {
+					test string
+				}{test: "test property"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.msg, func(t *testing.T) {
+			logger.Error(testCase.msg, testCase.fields)
+			logger.Warn(testCase.msg, testCase.fields)
+			logger.Info(testCase.msg, testCase.fields)
+			logger.Debug(testCase.msg, testCase.fields)
+
+			logs := logObserver.TakeAll()
+
+			if !assert.Len(t, logs, 4) {
+				return
+			}
+
+			levelOrder := []zapcore.Level{
+				zapcore.ErrorLevel,
+				zapcore.WarnLevel,
+				zapcore.InfoLevel,
+				zapcore.DebugLevel,
+			}
+
+			for i, level := range levelOrder {
+				assert.Equal(t, level, logs[i].Level)
+				assert.Equal(t, testCase.expectedMsg, logs[i].Message)
+				assert.Equal(t, testCase.expectedContext, logs[i].ContextMap())
+			}
+		})
+	}
+
+	t.Run("Do not log disabled levels", func(t *testing.T) {
+		zapCore, logObserver := observer.New(zapcore.InfoLevel)
+		logger := zapExtension.Wrap(zap.New(zapCore))
+
+		logger.Debug("should not be logged", func(e goengine.LoggerEntry) {
+			t.Error("fields should not be called")
+		})
+
+		assert.Equal(t, 0, logObserver.Len())
+	})
+}
+
+func TestWrapper_WithFields(t *testing.T) {
+	zapCore, logObserver := observer.New(zapcore.DebugLevel)
+	logger := zapExtension.Wrap(zap.New(zapCore))
+
+	t.Run("With fields", func(t *testing.T) {
+		loggerWithFields := logger.WithFields(func(e goengine.LoggerEntry) {
+			e.String("with field", "check")
+			e.String("val", "default")
+		})
+
+		loggerWithFields.Debug("test with nil", nil)
+		loggerWithFields.Debug("test with override", func(e goengine.LoggerEntry) {
+			e.String("val", "override")
+		})
+
+		logs := logObserver.TakeAll()
+		if assert.Len(t, logs, 2) {
+			assert.Equal(t, "test with nil", logs[0].Message)
+			assert.Equal(t, map[string]interface{}{
+				"with field": "check",
+				"val":        "default",
+			}, logs[0].ContextMap())
+
+			assert.Equal(t, "test with override", logs[1].Message)
+			assert.Equal(t, map[string]interface{}{
+				"with field": "check",
+				"val":        "override",
+			}, logs[1].ContextMap())
+		}
+	})
+
+	t.Run("With fields nil", func(t *testing.T) {
+		loggerWithFields := logger.WithFields(nil)
+		assert.Equal(t, logger, loggerWithFields)
+	})
+}
 
 func BenchmarkStandardLoggerEntry(b *testing.B) {
 	b.ReportAllocs()

--- a/logger.go
+++ b/logger.go
@@ -3,14 +3,21 @@ package goengine
 type (
 	// Logger a structured logger interface
 	Logger interface {
-		Error(msg string)
-		Warn(msg string)
-		Info(msg string)
-		Debug(msg string)
+		Error(msg string, fields func(LoggerEntry))
+		Warn(msg string, fields func(LoggerEntry))
+		Info(msg string, fields func(LoggerEntry))
+		Debug(msg string, fields func(LoggerEntry))
 
-		WithField(key string, val interface{}) Logger
-		WithFields(fields Fields) Logger
-		WithError(err error) Logger
+		WithFields(fields func(LoggerEntry)) Logger
+	}
+
+	// LoggerEntry represents the entry to be logger.
+	// This entry can be enhanced with more date.
+	LoggerEntry interface {
+		Int(k string, v int)
+		String(k, v string)
+		Error(err error)
+		Any(k string, v interface{})
 	}
 
 	// Fields a map of context provided to the logger

--- a/logger.go
+++ b/logger.go
@@ -15,6 +15,7 @@ type (
 	// This entry can be enhanced with more date.
 	LoggerEntry interface {
 		Int(k string, v int)
+		Int64(s string, v int64)
 		String(k, v string)
 		Error(err error)
 		Any(k string, v interface{})

--- a/logger_nop.go
+++ b/logger_nop.go
@@ -8,26 +8,18 @@ var NopLogger Logger = &nopLogger{}
 type nopLogger struct {
 }
 
-func (n *nopLogger) Error(string) {
+func (nopLogger) Error(msg string, fields func(LoggerEntry)) {
 }
 
-func (*nopLogger) Warn(string) {
+func (nopLogger) Warn(msg string, fields func(LoggerEntry)) {
 }
 
-func (*nopLogger) Info(string) {
+func (nopLogger) Info(msg string, fields func(LoggerEntry)) {
 }
 
-func (*nopLogger) Debug(string) {
+func (nopLogger) Debug(msg string, fields func(LoggerEntry)) {
 }
 
-func (n *nopLogger) WithField(string, interface{}) Logger {
-	return n
-}
-
-func (n *nopLogger) WithFields(Fields) Logger {
-	return n
-}
-
-func (n *nopLogger) WithError(error) Logger {
+func (n *nopLogger) WithFields(fields func(LoggerEntry)) Logger {
 	return n
 }


### PR DESCRIPTION
While benchmarking and testing I noticed that a lot of time was spend in `WithFields` and `WithError` for `Debug` calls that where disabled. To avoid this I have reworked the logger interface.  

I also noticed that the time spend on `notification` because it was using Reflection was high. So i split these into 2 field with specific types.