### PR TITLE
DB improvements

### DIFF
--- a/driver/sql/postgres/eventstore.go
+++ b/driver/sql/postgres/eventstore.go
@@ -85,6 +85,11 @@ func (e *EventStore) Create(ctx context.Context, streamName goengine.StreamName)
 		return ErrNoCreateTableQueries
 	}
 
+	if len(queries) == 1 {
+		_, err := e.db.ExecContext(ctx, queries[0])
+		return err
+	}
+
 	tx, err := e.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR improves:
- the projector query to have a lower cost
- To only use a transaction when inserting events when need
