### PR TITLE
Remove Queuer.Close

### DIFF
--- a/driver/sql/projection_notification_queue.go
+++ b/driver/sql/projection_notification_queue.go
@@ -114,5 +114,10 @@ func (nq *NotificationQueue) queueNotification(notification *ProjectionNotificat
 	nq.queueLock.Lock()
 	defer nq.queueLock.Unlock()
 
-	nq.queue <- notification
+	select {
+	case <-nq.done:
+		return
+	default:
+		nq.queue <- notification
+	}
 }

--- a/mocks/driver/sql/notification_queue.go
+++ b/mocks/driver/sql/notification_queue.go
@@ -34,18 +34,6 @@ func (m *NotificationQueuer) EXPECT() *NotificationQueuerMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method
-func (m *NotificationQueuer) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close
-func (mr *NotificationQueuerMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*NotificationQueuer)(nil).Close))
-}
-
 // Empty mocks base method
 func (m *NotificationQueuer) Empty() bool {
 	m.ctrl.T.Helper()
@@ -76,10 +64,10 @@ func (mr *NotificationQueuerMockRecorder) Next(arg0 interface{}) *gomock.Call {
 }
 
 // Open mocks base method
-func (m *NotificationQueuer) Open() chan struct{} {
+func (m *NotificationQueuer) Open() func() {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Open")
-	ret0, _ := ret[0].(chan struct{})
+	ret0, _ := ret[0].(func())
 	return ret0
 }
 


### PR DESCRIPTION
In order to cleanup the dual stop + close we introduce a queueLock allowing for a since queueCloser func to be returned by Open instead of a done channel which requires a Close call.