### PR TITLE
Fix go mod

### DIFF
--- a/driver/sql/projection_notification_processor_test.go
+++ b/driver/sql/projection_notification_processor_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package sql_test
 
 import (

--- a/mocks/gomod.go
+++ b/mocks/gomod.go
@@ -1,0 +1,7 @@
+// +build gomod
+
+package mocks
+
+import (
+	_ "github.com/golang/mock/mockgen/model"
+)


### PR DESCRIPTION
The PR fixes an issue where the mockgen app which is used by go generate is stripped when `go mod vendor` is called.