### PR TITLE
Avoid nil notifcation panic

### DIFF
--- a/mocks/gomod.go
+++ b/mocks/gomod.go
@@ -3,5 +3,5 @@
 package mocks
 
 import (
-	_ "github.com/golang/mock/mockgen/model"
+	_ "github.com/golang/mock/mockgen"
 )


### PR DESCRIPTION
When the notification is nil but an error occurs and debug log level is enabled the log field was calling `notification.No`.

