### PR TITLE
Add Amqp listener

### DIFF
--- a/extension/amqp/amqp.go
+++ b/extension/amqp/amqp.go
@@ -55,7 +55,7 @@ func DirectQueueConsume(amqpDSN, queue string) (Consume, error) {
 		}
 
 		// Since there can be multiple consumers, fair distribution of deliveries is required
-		deliveries, err := ch.Consume(queue, "", true, false, false, false, nil)
+		deliveries, err := ch.Consume(queue, "", false, false, false, false, nil)
 
 		return conn, deliveries, err
 	}, nil

--- a/extension/amqp/amqp.go
+++ b/extension/amqp/amqp.go
@@ -3,11 +3,20 @@ package amqp
 import (
 	"io"
 
+	"github.com/hellofresh/goengine"
 	"github.com/streadway/amqp"
 )
 
+// NotificationChannel represents a channel for notifications
+type NotificationChannel interface {
+	Publish(exchange, queue string, mandatory, immediate bool, msg amqp.Publishing) error
+	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
+	Qos(prefetchCount, prefetchSize int, global bool) error
+}
+
 // setup returns a connection and channel to be used for the Queue setup
 func setup(url, queue string) (io.Closer, NotificationChannel, error) {
+
 	conn, err := amqp.Dial(url)
 	if err != nil {
 		return nil, nil, err
@@ -25,7 +34,29 @@ func setup(url, queue string) (io.Closer, NotificationChannel, error) {
 	return conn, ch, nil
 }
 
-// NotificationChannel represents a channel for notifications
-type NotificationChannel interface {
-	Publish(exchange, queue string, mandatory, immediate bool, msg amqp.Publishing) error
+// DirectQueueConsume returns a Consume func that will connect to the provided AMQP server and create a queue for direct message delivery
+func DirectQueueConsume(amqpDSN, queue string) (Consume, error) {
+	switch {
+	case len(amqpDSN) == 0:
+		return nil, goengine.InvalidArgumentError("amqpDSN")
+	case len(queue) == 0:
+		return nil, goengine.InvalidArgumentError("queue")
+	}
+
+	return func() (io.Closer, <-chan amqp.Delivery, error) {
+		conn, ch, err := setup(amqpDSN, queue)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Indicate we only want 1 message to be acknowledge at a time.
+		if err := ch.Qos(1, 0, false); err != nil {
+			return nil, nil, err
+		}
+
+		// Exclusive consumer
+		deliveries, err := ch.Consume(queue, "", true, false, false, false, nil)
+
+		return conn, deliveries, err
+	}, nil
 }

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type mockAcknowledger struct {
+}
+
+func (ack mockAcknowledger) Ack(tag uint64, multiple bool) error {
+	return nil
+}
+
+func (ack mockAcknowledger) Nack(tag uint64, multiple bool, requeue bool) error {
+	return nil
+}
+
+func (ack mockAcknowledger) Reject(tag uint64, requeue bool) error {
+	return nil
+}
+
 type mockConnection struct {
 }
 

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -21,3 +21,18 @@ func (ch mockChannel) Publish(
 ) error {
 	return nil
 }
+
+func (ch mockChannel) Consume(
+	queue,
+	consumer string,
+	autoAck,
+	exclusive,
+	noLocal,
+	noWait bool,
+	args amqp.Table,
+) (<-chan amqp.Delivery, error) {
+	return make(chan amqp.Delivery), nil
+}
+func (ch mockChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
+	return nil
+}

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -1,6 +1,15 @@
+// +build unit
+
 package amqp_test
 
-import "github.com/streadway/amqp"
+import (
+	"testing"
+
+	"github.com/hellofresh/goengine"
+	goengineAmqp "github.com/hellofresh/goengine/extension/amqp"
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+)
 
 type mockConnection struct {
 }
@@ -35,4 +44,21 @@ func (ch mockChannel) Consume(
 }
 func (ch mockChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
 	return nil
+}
+
+func TestDirectQueueConsume(t *testing.T) {
+	t.Run("Invalid arguments", func(t *testing.T) {
+		_, err := goengineAmqp.DirectQueueConsume("http://localhost:5672/", "my-queue")
+		assert.Equal(t, goengine.InvalidArgumentError("amqpDSN"), err)
+
+		_, err = goengineAmqp.DirectQueueConsume("amqp://localhost:5672/", "")
+		assert.Equal(t, goengine.InvalidArgumentError("queue"), err)
+	})
+
+	t.Run("Returns amqp.Consume", func(t *testing.T) {
+		c, err := goengineAmqp.DirectQueueConsume("amqp://localhost:5672/", "my-queue")
+		assert.NoError(t, err)
+		assert.NotNil(t, c)
+		assert.IsType(t, (goengineAmqp.Consume)(nil), c)
+	})
 }

--- a/extension/amqp/listener.go
+++ b/extension/amqp/listener.go
@@ -1,0 +1,132 @@
+package amqp
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/hellofresh/goengine"
+	"github.com/hellofresh/goengine/driver/sql"
+	"github.com/mailru/easyjson"
+	"github.com/streadway/amqp"
+)
+
+// Ensure Listener implements sql.Listener
+var _ sql.Listener = &Listener{}
+
+type (
+	// Consume returns a channel of amqp.Delivery's and a related closer or an error
+	Consume func() (io.Closer, <-chan amqp.Delivery, error)
+
+	// Listener consumes messages from an queue
+	Listener struct {
+		consume              Consume
+		minReconnectInterval time.Duration
+		maxReconnectInterval time.Duration
+		logger               goengine.Logger
+	}
+)
+
+// NewListener returns a new Listener
+func NewListener(
+	consume Consume,
+	minReconnectInterval time.Duration,
+	maxReconnectInterval time.Duration,
+	logger goengine.Logger,
+) (*Listener, error) {
+	switch {
+	case consume == nil:
+		return nil, goengine.InvalidArgumentError("consume")
+	}
+
+	if logger == nil {
+		logger = goengine.NopLogger
+	}
+
+	return &Listener{
+		consume:              consume,
+		minReconnectInterval: minReconnectInterval,
+		maxReconnectInterval: maxReconnectInterval,
+		logger:               logger,
+	}, nil
+}
+
+// Listen receives messages from a queue, transforms them into a sql.ProjectionNotification and calls the trigger
+func (l *Listener) Listen(ctx context.Context, trigger sql.ProjectionTrigger) error {
+	var nextReconnect time.Time
+	reconnectInterval := l.minReconnectInterval
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+		}
+
+		conn, deliveries, err := l.consume()
+		if err != nil {
+			l.logger.Error("failed to start consuming amqp messages", func(entry goengine.LoggerEntry) {
+				entry.Error(err)
+				entry.String("reconnect_in", reconnectInterval.String())
+			})
+
+			time.Sleep(reconnectInterval)
+			reconnectInterval *= 2
+			if reconnectInterval > l.maxReconnectInterval {
+				reconnectInterval = l.maxReconnectInterval
+			}
+			continue
+		}
+		reconnectInterval = l.minReconnectInterval
+		nextReconnect = time.Now().Add(reconnectInterval)
+
+		l.consumeMessages(ctx, conn, deliveries, trigger)
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			time.Sleep(time.Until(nextReconnect))
+		}
+	}
+}
+
+func (l *Listener) consumeMessages(ctx context.Context, conn io.Closer, deliveries <-chan amqp.Delivery, trigger sql.ProjectionTrigger) {
+	defer func() {
+		if conn == nil {
+			return
+		}
+
+		if err := conn.Close(); err != nil {
+			l.logger.Error("failed to close amqp connection", func(entry goengine.LoggerEntry) {
+				entry.Error(err)
+			})
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-deliveries:
+			if !ok {
+				return
+			}
+
+			notification := &sql.ProjectionNotification{}
+			if err := easyjson.Unmarshal(msg.Body, notification); err != nil {
+				l.logger.Error("failed to unmarshal delivery, dropping message", func(entry goengine.LoggerEntry) {
+					entry.Error(err)
+				})
+				continue
+			}
+
+			if err := trigger(ctx, notification); err != nil {
+				l.logger.Error("failed to project notification", func(entry goengine.LoggerEntry) {
+					entry.Error(err)
+					entry.Int64("notification.no", notification.No)
+					entry.String("notification.aggregate_id", notification.AggregateID)
+				})
+			}
+		}
+	}
+}

--- a/extension/amqp/listener.go
+++ b/extension/amqp/listener.go
@@ -120,6 +120,15 @@ func (l *Listener) consumeMessages(ctx context.Context, conn io.Closer, deliveri
 				continue
 			}
 
+			if err := msg.Ack(false); err != nil {
+				l.logger.Error("failed to acknowledge notification delivery", func(entry goengine.LoggerEntry) {
+					entry.Error(err)
+					entry.Int64("notification.no", notification.No)
+					entry.String("notification.aggregate_id", notification.AggregateID)
+				})
+				continue
+			}
+
 			if err := trigger(ctx, notification); err != nil {
 				l.logger.Error("failed to project notification", func(entry goengine.LoggerEntry) {
 					entry.Error(err)
@@ -127,6 +136,7 @@ func (l *Listener) consumeMessages(ctx context.Context, conn io.Closer, deliveri
 					entry.String("notification.aggregate_id", notification.AggregateID)
 				})
 			}
+
 		}
 	}
 }

--- a/extension/amqp/listener_test.go
+++ b/extension/amqp/listener_test.go
@@ -1,0 +1,174 @@
+// +build unit
+
+package amqp_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/hellofresh/goengine"
+	"github.com/hellofresh/goengine/driver/sql"
+	"github.com/hellofresh/goengine/extension/amqp"
+	goengineLogger "github.com/hellofresh/goengine/extension/logrus"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	libamqp "github.com/streadway/amqp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListener_Listen(t *testing.T) {
+	t.Run("Listen, consume and stop", func(t *testing.T) {
+		ensure := require.New(t)
+
+		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+		defer ctxCancel()
+
+		consumeCalls := 0
+		consume := func() (io.Closer, <-chan libamqp.Delivery, error) {
+			consumeCalls++
+			ch := make(chan libamqp.Delivery, 2)
+			ch <- libamqp.Delivery{
+				Body: []byte(`{"no": 1, "aggregate_id": "8150276e-34fe-49d9-aeae-a35af0040a4f"}`),
+			}
+			ch <- libamqp.Delivery{
+				Body: []byte(`{"no": 2, "aggregate_id": "8150276e-34fe-49d9-aeae-a35af0040a4f"}`),
+			}
+			return nil, ch, nil
+		}
+		triggerCalls := 0
+		trigger := func(ctx context.Context, notification *sql.ProjectionNotification) error {
+			triggerCalls++
+			switch triggerCalls {
+			case 1:
+				ensure.Equal(&sql.ProjectionNotification{No: 1, AggregateID: "8150276e-34fe-49d9-aeae-a35af0040a4f"}, notification)
+			case 2:
+				ensure.Equal(&sql.ProjectionNotification{No: 2, AggregateID: "8150276e-34fe-49d9-aeae-a35af0040a4f"}, notification)
+				ctxCancel()
+			default:
+				ensure.Fail("Only 2 calls to trigger where expected")
+			}
+			return nil
+		}
+		logger, loggerHook := getLogger()
+
+		listener, err := amqp.NewListener(consume, time.Millisecond, time.Millisecond, logger)
+		ensure.NoError(err)
+
+		err = listener.Listen(ctx, trigger)
+
+		ensure.Equal(context.Canceled, err)
+		ensure.Equal(1, consumeCalls)
+		ensure.Equal(2, triggerCalls)
+		ensure.Len(loggerHook.Entries, 0)
+	})
+
+	t.Run("Reconnect with exponential back-off", func(t *testing.T) {
+		ensure := require.New(t)
+
+		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+		defer ctxCancel()
+
+		var consumeCalls []time.Time
+		consume := func() (io.Closer, <-chan libamqp.Delivery, error) {
+			consumeCalls = append(consumeCalls, time.Now())
+			if len(consumeCalls) == 5 {
+				ctxCancel()
+			}
+
+			return nil, nil, fmt.Errorf("failure %d", len(consumeCalls))
+		}
+
+		logger, loggerHook := getLogger()
+
+		listener, err := amqp.NewListener(consume, time.Millisecond, 6*time.Millisecond, logger)
+		ensure.NoError(err)
+
+		err = listener.Listen(ctx, func(ctx context.Context, notification *sql.ProjectionNotification) error {
+			ensure.Fail("Trigger should ever be called")
+			return nil
+		})
+
+		ensure.Equal(context.Canceled, err)
+
+		reconnectIntervals := []time.Duration{time.Millisecond, time.Millisecond * 2, time.Millisecond * 4, time.Millisecond * 6, time.Millisecond * 6}
+		ensure.Len(consumeCalls, len(reconnectIntervals))
+		for i := 1; i < len(reconnectIntervals); i++ {
+			expectedInterval := reconnectIntervals[i-1]
+			interval := consumeCalls[i].Sub(consumeCalls[i-1])
+
+			if expectedInterval > interval || interval > (expectedInterval+time.Millisecond) {
+				assert.Fail(t, fmt.Sprintf("Invalid interval after consume %d (got %s expected between %s and %s)", i, interval, expectedInterval, (expectedInterval+time.Millisecond)))
+			}
+		}
+
+		// Ensure we get log output
+		logEntries := loggerHook.AllEntries()
+		ensure.Len(logEntries, len(reconnectIntervals))
+		for i, log := range logEntries {
+			assert.Equal(t, log.Level, logrus.ErrorLevel)
+			assert.Equal(t, log.Message, "failed to start consuming amqp messages")
+			assert.Equal(t, fmt.Errorf("failure %d", i+1), log.Data["error"])
+			assert.Equal(t, reconnectIntervals[i].String(), log.Data["reconnect_in"])
+		}
+	})
+
+	t.Run("Listen, consume and reconnect", func(t *testing.T) {
+		ensure := require.New(t)
+
+		ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+		defer ctxCancel()
+
+		consumeCalls := 0
+		consume := func() (io.Closer, <-chan libamqp.Delivery, error) {
+			consumeCalls++
+			ch := make(chan libamqp.Delivery, 2)
+			ch <- libamqp.Delivery{
+				Body: []byte(`{"no": 1, "aggregate_id": "8150276e-34fe-49d9-aeae-a35af0040a4f"}`),
+			}
+			ch <- libamqp.Delivery{
+				Body: []byte(`{"no": 2, "aggregate_id": "8150276e-34fe-49d9-aeae-a35af0040a4f"}`),
+			}
+			close(ch)
+			return nil, ch, nil
+		}
+		triggerCalls := 0
+		trigger := func(ctx context.Context, notification *sql.ProjectionNotification) error {
+			triggerCalls++
+			switch triggerCalls {
+			case 1, 3:
+				ensure.Equal(&sql.ProjectionNotification{No: 1, AggregateID: "8150276e-34fe-49d9-aeae-a35af0040a4f"}, notification)
+			case 2, 4:
+				ensure.Equal(&sql.ProjectionNotification{No: 2, AggregateID: "8150276e-34fe-49d9-aeae-a35af0040a4f"}, notification)
+			default:
+				ensure.Fail("Only 2 calls to trigger where expected")
+			}
+			if triggerCalls == 4 {
+				ctxCancel()
+			}
+			return nil
+		}
+
+		logger, loggerHook := getLogger()
+
+		listener, err := amqp.NewListener(consume, time.Millisecond, time.Millisecond, logger)
+		ensure.NoError(err)
+
+		err = listener.Listen(ctx, trigger)
+
+		ensure.Equal(context.Canceled, err)
+		ensure.Equal(2, consumeCalls)
+		ensure.Equal(4, triggerCalls)
+		ensure.Len(loggerHook.Entries, 0)
+	})
+}
+
+func getLogger() (goengine.Logger, *test.Hook) {
+	logger, loggerHook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	return goengineLogger.Wrap(logger), loggerHook
+}

--- a/extension/amqp/publisher_test.go
+++ b/extension/amqp/publisher_test.go
@@ -58,10 +58,3 @@ func TestNotificationPublisher_Publish(t *testing.T) {
 		ensure.Len(loggerHook.Entries, 0)
 	})
 }
-
-//func getLogger() (goengine.Logger, *test.Hook) {
-//	logger, loggerHook := test.NewNullLogger()
-//	logger.SetLevel(logrus.DebugLevel)
-//
-//	return goengineLogger.Wrap(logger), loggerHook
-//}

--- a/extension/amqp/publisher_test.go
+++ b/extension/amqp/publisher_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package amqp_test
 
 import (
@@ -8,9 +10,6 @@ import (
 	"github.com/hellofresh/goengine"
 	"github.com/hellofresh/goengine/driver/sql"
 	goengineAmqp "github.com/hellofresh/goengine/extension/amqp"
-	goengineLogger "github.com/hellofresh/goengine/extension/logrus"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,9 +59,9 @@ func TestNotificationPublisher_Publish(t *testing.T) {
 	})
 }
 
-func getLogger() (goengine.Logger, *test.Hook) {
-	logger, loggerHook := test.NewNullLogger()
-	logger.SetLevel(logrus.DebugLevel)
-
-	return goengineLogger.Wrap(logger), loggerHook
-}
+//func getLogger() (goengine.Logger, *test.Hook) {
+//	logger, loggerHook := test.NewNullLogger()
+//	logger.SetLevel(logrus.DebugLevel)
+//
+//	return goengineLogger.Wrap(logger), loggerHook
+//}

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271 h1:WhxRHzgeVGETMlmVfqhRn8RIeeNoPr2Czh33I4Zdccw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=


### PR DESCRIPTION
In order to allow goengine to use AMQP to handle event notifications we need to be able to listen to them.
This PR adds a sql.Listener implementation for goengine.