### PR TITLE
Refactor Aggregate/Stream projectors

### DIFF
--- a/driver/sql/projection_notification_processor.go
+++ b/driver/sql/projection_notification_processor.go
@@ -46,7 +46,7 @@ func NewBackgroundProcessor(
 		metrics = NopMetrics
 	}
 	if notificationQueue == nil {
-		notificationQueue = newNotificationQueue(queueBuffer, 0, metrics)
+		notificationQueue = NewNotificationQueue(queueBuffer, 0, metrics)
 	}
 
 	return &ProjectionNotificationProcessor{

--- a/driver/sql/projection_notification_queue.go
+++ b/driver/sql/projection_notification_queue.go
@@ -35,7 +35,7 @@ type (
 	}
 )
 
-func newNotificationQueue(queueBuffer int, retryDelay time.Duration, metrics Metrics) *NotificationQueue {
+func NewNotificationQueue(queueBuffer int, retryDelay time.Duration, metrics Metrics) *NotificationQueue {
 	if retryDelay == 0 {
 		retryDelay = time.Millisecond * 50
 	}

--- a/driver/sql/projector_notification.go
+++ b/driver/sql/projector_notification.go
@@ -24,14 +24,14 @@ type notificationProjector struct {
 }
 
 // newNotificationProjector returns a new notificationProjector
-func newNotificationProjector(
+func NewNotificationProjector(
 	db *sql.DB,
 	storage ProjectorStorage,
 	eventHandlers map[string]goengine.MessageHandler,
 	eventLoader EventStreamLoader,
 	resolver goengine.MessagePayloadResolver,
 	logger goengine.Logger,
-) (*notificationProjector, error) {
+) (ProjectionTrigger, error) {
 	switch {
 	case db == nil:
 		return nil, goengine.InvalidArgumentError("db")
@@ -49,14 +49,16 @@ func newNotificationProjector(
 		logger = goengine.NopLogger
 	}
 
-	return &notificationProjector{
+	projector := &notificationProjector{
 		db:          db,
 		storage:     storage,
 		handlers:    wrapProjectionHandlers(eventHandlers),
 		eventLoader: eventLoader,
 		resolver:    resolver,
 		logger:      logger,
-	}, nil
+	}
+
+	return projector.Execute, nil
 }
 
 // Execute triggers the projections for the notification


### PR DESCRIPTION
This PR introduces following changes

- Separate handler for out of sync or nil notifications
- Removes Run and RunAndListen functions those were previously used to execute and manages state of the projections and also for listening to changes in event store
- Introduces projection error handler that wraps the ProjectionTrigger to check and handle errors
