### PR TITLE
Use golang version matrix 

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ lint ]
 
+    strategy:
+      matrix:
+        go: [ '~1.17', '~1.18' ]
     services:
       postgres:
         image: postgres:10
@@ -40,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.17
+          go-version: ${{ matrix.go }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run unit tests


### PR DESCRIPTION
This change allows testing goengine for both golang 1.17 and 1.18