### PR TITLE
Use golang version matrix

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,10 +16,14 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
 
-  test:
-    name: Test
+  go-test:
+    name: Go ${{ matrix.go }} Test
     runs-on: ubuntu-latest
     needs: [ lint ]
+
+    strategy:
+      matrix:
+        go: [ '~1.17', '~1.18' ]
 
     services:
       postgres:
@@ -40,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.17
+          go-version: ${{ matrix.go }}
       - name: Check out code
         uses: actions/checkout@v2
       - name: Run unit tests
@@ -51,3 +55,12 @@ jobs:
         run: make test-integration
         env:
           POSTGRES_DSN: postgres://goengine:goengine@localhost:${{ job.services.postgres.ports[5432] }}/goengine?sslmode=disable
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [ go-test ]
+
+    steps:
+      - name: Done
+        run: echo "All Golang versions tests are Green!"


### PR DESCRIPTION
This change allows testing goengine for both golang 1.17 and 1.18