### PR TITLE
rename unused vars

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           only-new-issues: ${{ github.event_name == 'pull_request' }}
 

--- a/driver/inmemory/eventstore.go
+++ b/driver/inmemory/eventstore.go
@@ -38,7 +38,7 @@ func NewEventStore(logger goengine.Logger) *EventStore {
 }
 
 // Create creates an event stream
-func (i *EventStore) Create(ctx context.Context, streamName goengine.StreamName) error {
+func (i *EventStore) Create(_ context.Context, streamName goengine.StreamName) error {
 	if _, found := i.streams[streamName]; found {
 		return ErrStreamExistsAlready
 	}
@@ -49,7 +49,7 @@ func (i *EventStore) Create(ctx context.Context, streamName goengine.StreamName)
 }
 
 // HasStream returns true if the stream exists
-func (i *EventStore) HasStream(ctx context.Context, streamName goengine.StreamName) bool {
+func (i *EventStore) HasStream(_ context.Context, streamName goengine.StreamName) bool {
 	_, found := i.streams[streamName]
 
 	return found
@@ -57,7 +57,7 @@ func (i *EventStore) HasStream(ctx context.Context, streamName goengine.StreamNa
 
 // Load returns a list of events based on the provided conditions
 func (i *EventStore) Load(
-	ctx context.Context,
+	_ context.Context,
 	streamName goengine.StreamName,
 	fromNumber int64,
 	count *uint,

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -58,7 +58,7 @@ func (ch mockChannel) Consume(
 ) (<-chan amqp.Delivery, error) {
 	return make(chan amqp.Delivery), nil
 }
-func (ch mockChannel) Qos(prefetchCount, prefetchSize int, global bool) error {
+func (ch mockChannel) Qos(_, prefetchSize int, global bool) error {
 	return nil
 }
 

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -58,7 +58,7 @@ func (ch mockChannel) Consume(
 ) (<-chan amqp.Delivery, error) {
 	return make(chan amqp.Delivery), nil
 }
-func (ch mockChannel) Qos(_, _ int, global bool) error {
+func (ch mockChannel) Qos(_, _ int, _ bool) error {
 	return nil
 }
 

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -58,7 +58,7 @@ func (ch mockChannel) Consume(
 ) (<-chan amqp.Delivery, error) {
 	return make(chan amqp.Delivery), nil
 }
-func (ch mockChannel) Qos(_, prefetchSize int, global bool) error {
+func (ch mockChannel) Qos(_, _ int, global bool) error {
 	return nil
 }
 

--- a/extension/amqp/amqp_test.go
+++ b/extension/amqp/amqp_test.go
@@ -58,7 +58,7 @@ func (ch mockChannel) Consume(
 ) (<-chan amqp.Delivery, error) {
 	return make(chan amqp.Delivery), nil
 }
-func (ch mockChannel) Qos(_, _ int, _ bool) error {
+func (ch mockChannel) Qos(int, int, bool) error {
 	return nil
 }
 

--- a/logger_nop.go
+++ b/logger_nop.go
@@ -8,18 +8,18 @@ var NopLogger Logger = &nopLogger{}
 type nopLogger struct {
 }
 
-func (nopLogger) Error(_ string, _ func(LoggerEntry)) {
+func (nopLogger) Error(string, func(LoggerEntry)) {
 }
 
-func (nopLogger) Warn(_ string, _ func(LoggerEntry)) {
+func (nopLogger) Warn(string, func(LoggerEntry)) {
 }
 
-func (nopLogger) Info(_ string, _ func(LoggerEntry)) {
+func (nopLogger) Info(string, func(LoggerEntry)) {
 }
 
-func (nopLogger) Debug(_ string, _ func(LoggerEntry)) {
+func (nopLogger) Debug(string, func(LoggerEntry)) {
 }
 
-func (n *nopLogger) WithFields(_ func(LoggerEntry)) Logger {
+func (n *nopLogger) WithFields(func(LoggerEntry)) Logger {
 	return n
 }

--- a/logger_nop.go
+++ b/logger_nop.go
@@ -8,18 +8,18 @@ var NopLogger Logger = &nopLogger{}
 type nopLogger struct {
 }
 
-func (nopLogger) Error(msg string, fields func(LoggerEntry)) {
+func (nopLogger) Error(_ string, _ func(LoggerEntry)) {
 }
 
-func (nopLogger) Warn(msg string, fields func(LoggerEntry)) {
+func (nopLogger) Warn(_ string, _ func(LoggerEntry)) {
 }
 
-func (nopLogger) Info(msg string, fields func(LoggerEntry)) {
+func (nopLogger) Info(_ string, _ func(LoggerEntry)) {
 }
 
-func (nopLogger) Debug(msg string, fields func(LoggerEntry)) {
+func (nopLogger) Debug(_ string, _ func(LoggerEntry)) {
 }
 
-func (n *nopLogger) WithFields(fields func(LoggerEntry)) Logger {
+func (n *nopLogger) WithFields(_ func(LoggerEntry)) Logger {
 	return n
 }

--- a/metadata/matcher.go
+++ b/metadata/matcher.go
@@ -65,7 +65,7 @@ func WithConstraint(parent Matcher, field string, operator Operator, value inter
 	}
 }
 
-func (*emptyMatcher) Iterate(_ func(constraint Constraint)) {
+func (*emptyMatcher) Iterate(func(constraint Constraint)) {
 }
 
 func (c *constraintMatcher) Iterate(callback func(constraint Constraint)) {

--- a/metadata/matcher.go
+++ b/metadata/matcher.go
@@ -65,7 +65,7 @@ func WithConstraint(parent Matcher, field string, operator Operator, value inter
 	}
 }
 
-func (*emptyMatcher) Iterate(callback func(constraint Constraint)) {
+func (*emptyMatcher) Iterate(_ func(constraint Constraint)) {
 }
 
 func (c *constraintMatcher) Iterate(callback func(constraint Constraint)) {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -63,7 +63,7 @@ var (
 	_ easyjson.Marshaler = new(emptyData)
 )
 
-func (*emptyData) Value(_ string) interface{} {
+func (*emptyData) Value(string) interface{} {
 	return nil
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -63,7 +63,7 @@ var (
 	_ easyjson.Marshaler = new(emptyData)
 )
 
-func (*emptyData) Value(key string) interface{} {
+func (*emptyData) Value(_ string) interface{} {
 	return nil
 }
 


### PR DESCRIPTION
Fix golint issues: rename unused vars.
Also updating golangci-lint-action to version v3 in test workflow.